### PR TITLE
v3 - audio - audio.Queue implementation from v2 playback queue

### DIFF
--- a/audio/audiouri/uri.go
+++ b/audio/audiouri/uri.go
@@ -1,0 +1,212 @@
+// Package audiouri provides conversions for common sounds to asterisk-supported audio URIs
+package audiouri
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// SupportedPlaybackPrefixes is a list of valid prefixes
+// for media URIs.
+var SupportedPlaybackPrefixes = []string{
+	"sound", "recording", "number", "digits", "characters", "tone",
+}
+
+func init() {
+	sort.Strings(SupportedPlaybackPrefixes)
+}
+
+// WaitURI returns the set of media URIs for the
+// given period of silence.
+func WaitURI(t time.Duration) []string {
+	q := []string{}
+	for i := time.Duration(0); i <= t; i += time.Second {
+		q = append(q, "sound:silence/1")
+	}
+	return q
+}
+
+// NumberURI returns the media URI to play
+// the given number.
+func NumberURI(number int) string {
+	return fmt.Sprintf("number:%d", number)
+}
+
+// DigitsURI returns the set of media URIs to
+// play the given digits.
+func DigitsURI(digits string, hash string) []string {
+	if strings.Contains(digits, "#") && hash != "" {
+		hash = "sound:char/" + hash
+
+		// Split the digits by each hash
+		pieces := strings.Split(digits, "#")
+
+		// Get the strings for each digit substring
+		newDigits := []string{}
+		for i, p := range pieces {
+			newDigits = append(newDigits, DigitsURI(p, hash)...)
+			if len(pieces) > i+1 {
+				// If this wasn't the last piece, add a hash
+				newDigits = append(newDigits, hash)
+			}
+		}
+		return newDigits
+	}
+
+	// Handle '*' to 'star' conversion
+	if strings.Contains(digits, "*") {
+		star := "sound:char/star"
+
+		// Split the digits by each *
+		pieces := strings.Split(digits, "*")
+
+		// Get the strings for each digit substring
+		newDigits := []string{}
+		for i, p := range pieces {
+			newDigits = append(newDigits, DigitsURI(p, hash)...)
+			if len(pieces) > i+1 {
+				// If this wasn't the last piece, add a star
+				newDigits = append(newDigits, star)
+			}
+		}
+		return newDigits
+	}
+
+	// Otherwise, we can simply use the normal "digits:" URI
+	if len(digits) < 1 {
+		return []string{}
+	}
+	return []string{"digits:" + digits}
+}
+
+// DateTimeURI returns the set of media URIs for playing
+// the current date and time.
+func DateTimeURI(t time.Time) (ret []string) {
+	ret = []string{}
+
+	ret = append(ret,
+		fmt.Sprintf("sound:digits/day-%d", t.Weekday()),
+		fmt.Sprintf("sound:digits/mon-%d", t.Month()-1),
+		NumberURI(t.Day()),
+	)
+
+	// Convert to 12-hour time
+	pm := false
+	hour := t.Hour()
+	switch {
+	case hour == 0:
+		hour = 12
+	case hour == 12:
+		pm = true
+	case hour > 12:
+		hour -= 12
+		pm = true
+	default:
+	}
+	ret = append(ret, NumberURI(hour))
+
+	// Humanize the minutes
+	minute := t.Minute()
+	switch {
+	case minute == 0:
+		ret = append(ret, "sound:digits/oclock")
+	case minute < 10:
+		ret = append(ret,
+			"sound:digits/oh",
+			NumberURI(minute),
+		)
+	default:
+		ret = append(ret, NumberURI(minute))
+	}
+
+	// Add am/pm suffix
+	if pm {
+		ret = append(ret, "sound:digits/p-m")
+	} else {
+		ret = append(ret, "sound:digits/a-m")
+	}
+
+	// Add the year
+	ret = append(ret, NumberURI(t.Year()))
+
+	return
+}
+
+// DurationURI returns the set of media URIs for playing
+// the given duration, in human terms (days, hours, minutes, seconds).
+// If any of these terms are zero, they will not be spoken.
+func DurationURI(dur time.Duration) (ret []string) {
+	days := int(dur.Hours() / 24)
+	hours := int(dur.Hours()) % 24
+	minutes := int(dur.Minutes()) % 60
+	seconds := int(dur.Seconds()) % 60
+
+	ret = []string{}
+
+	if days > 0 {
+		ret = append(ret, NumberURI(days))
+		if days > 1 {
+			ret = append(ret, "sound:time/days")
+		} else {
+			ret = append(ret, "sound:time/day")
+		}
+	}
+
+	if hours > 0 {
+		ret = append(ret, NumberURI(hours))
+		if hours > 1 {
+			ret = append(ret, "sound:time/hours")
+		} else {
+			ret = append(ret, "sound:time/hour")
+		}
+	}
+
+	if minutes > 0 {
+		ret = append(ret, NumberURI(minutes))
+		if minutes > 1 {
+			ret = append(ret, "sound:time/minutes")
+		} else {
+			ret = append(ret, "sound:time/minute")
+		}
+	}
+
+	if seconds > 0 {
+		ret = append(ret, NumberURI(seconds))
+		if seconds > 1 {
+			ret = append(ret, "sound:time/seconds")
+		} else {
+			ret = append(ret, "sound:time/second")
+		}
+	}
+
+	return
+}
+
+// RecordingURI returns the media URI for playing an
+// Asterisk StoredRecording
+func RecordingURI(name string) string {
+	return "recording:" + name
+}
+
+// ToneURI returns the media URI for playing the
+// given tone, which may be a system-defined indication
+// or an explicit tone pattern construction.
+func ToneURI(name string) string {
+	return "tone:" + name
+}
+
+// checkAudioURI checks if the audio URI is formatted properly
+func checkAudioURI(uri string) error {
+	l := strings.Split(uri, ":")
+	if len(l) != 2 {
+		return fmt.Errorf("Audio URI %s is not formatted properly", uri)
+	}
+
+	if sort.SearchStrings(SupportedPlaybackPrefixes, l[0]) == len(SupportedPlaybackPrefixes) {
+		return fmt.Errorf("Audio URI prefix %s not supported", l[0])
+	}
+
+	return nil
+}

--- a/audio/play.go
+++ b/audio/play.go
@@ -172,6 +172,6 @@ func (err timeoutErr) Error() string {
 	return err.msg
 }
 
-func (err timeoutErr) IsTimeout() bool {
+func (err timeoutErr) Timeout() bool {
 	return true
 }

--- a/audio/queue.go
+++ b/audio/queue.go
@@ -1,0 +1,184 @@
+package audio
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/CyCoreSystems/ari"
+	v2 "github.com/CyCoreSystems/ari/v2"
+
+	"golang.org/x/net/context"
+)
+
+// Options describes various options which
+// are available to playback operations.
+type Options struct {
+	// ID is an optional ID to use for the playback's ID. If one
+	// is not supplied, an ID will be randomly generated internally.
+	// NOTE that this ID will only be used for the FIRST playback
+	// in a queue.  All subsequent playback IDs will be randomly generated.
+	ID string
+
+	// DTMF is an optional channel for received DTMF tones received during the playback.
+	// This channel will NOT be closed by the playback.
+	DTMF chan<- *v2.ChannelDtmfReceived
+
+	// ExitOnDTMF defines a list of DTMF digits on receipt of which will
+	// terminate the playback of the queue.  You may set this to AllDTMF
+	// in order to match any DTMF digit.
+	ExitOnDTMF string
+
+	// Done is an optional channel for receiving notification when the playback
+	// is complete.  This is useful if the playback is to be executed asynchronously.
+	// This channel will be closed by the playback when playback the is complete.
+	Done chan<- struct{}
+}
+
+// Queue represents a sequence of audio playbacks
+// which are to be played on the associated Player
+type Queue struct {
+	queue        []string // List of mediaURI to be played
+	mu           sync.Mutex
+	s            ari.Subscriber
+	receivedDTMF string // Storage for received DTMF, if we are listening for them
+}
+
+// NewQueue creates (but does not start) a new playback queue.
+func NewQueue(s ari.Subscriber) *Queue {
+	return &Queue{
+		s: s,
+	}
+}
+
+// Add appends one or more mediaURIs to the playback queue
+func (pq *Queue) Add(mediaURIs ...string) {
+	// Make sure our queue exists
+	pq.mu.Lock()
+	if pq.queue == nil {
+		pq.queue = []string{}
+	}
+	pq.mu.Unlock()
+
+	// Add each media URI to the queue
+	for _, u := range mediaURIs {
+		if u == "" {
+			continue
+		}
+
+		pq.mu.Lock()
+		pq.queue = append(pq.queue, u)
+		pq.mu.Unlock()
+	}
+}
+
+// Flush empties a playback queue.
+// NOTE that this does NOT stop the current playback.
+func (pq *Queue) Flush() {
+	pq.mu.Lock()
+	pq.queue = []string{}
+	pq.mu.Unlock()
+}
+
+// ReceivedDTMF returns any DTMF which has been received
+// by the PlaybackQueue.
+func (pq *Queue) ReceivedDTMF() string {
+	return pq.receivedDTMF
+}
+
+// Play starts the playback of the queue to the Player.
+func (pq *Queue) Play(ctx context.Context, p Player, opts *Options) error {
+	if opts == nil {
+		opts = &Options{}
+	}
+
+	// NOTE: this code used to call Subscribe("ChannelDtmfReceived") twice. This
+	// was /fine/ until trying to unit test. We use one subscription
+	// and send out to dtmfChan depending on whether opts.DTMF is not nil.
+	// This simplifies the workflow and ensures we have a 1-1 correlation between
+	// a subscription and a Queue
+
+	dtmfChan := make(chan *v2.ChannelDtmfReceived)
+	dtmfSub := pq.s.Subscribe("ChannelDtmfReceived")
+
+	handlingDTMF := false
+
+	// Handle any options we were given
+	if opts != nil {
+		// Close the done channel when we finish,
+		// if we were given one.
+		if opts.Done != nil {
+			defer close(opts.Done)
+		}
+
+		// Listen for DTMF, if we were asked to do so
+		if opts.DTMF != nil {
+			handlingDTMF = true
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case e := <-dtmfChan:
+						opts.DTMF <- e
+					}
+				}
+			}()
+		}
+	}
+
+	// if we aren't forwarding to opts.DTMF, then discard DTMF messages
+	if !handlingDTMF {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+				case <-dtmfChan:
+				}
+			}
+		}()
+	}
+
+	// Record any DTMF (this is separate from opts.DTMF) so that we can
+	//  - Service ReceivedDTMF requests
+	//  - Exit if we were given an ExitOnDTMF list
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
+	go func() {
+		defer dtmfSub.Cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e := <-dtmfSub.C:
+				if e == nil {
+					return
+				}
+				dtmfChan <- e.(*v2.ChannelDtmfReceived)
+				digit := e.(*v2.ChannelDtmfReceived).Digit
+				pq.receivedDTMF += digit
+				if strings.Contains(opts.ExitOnDTMF, digit) {
+					cancel()
+				}
+			}
+		}
+	}()
+
+	// Start the playback
+	for i := 0; len(pq.queue) > i; i++ {
+		// Make sure our context isn't closed
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// Get the next clip
+		err := Play(ctx, pq.s, p, pq.queue[i])
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}

--- a/audio/queue_test.go
+++ b/audio/queue_test.go
@@ -29,9 +29,11 @@ func TestQueueTimeout(t *testing.T) {
 
 	err := q.Play(ctx, player, nil)
 
-	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+	if !isTimeout(err) {
 		t.Errorf("Expected timeout error, got: '%v'", err)
-	} else if err.Error() != "Timeout waiting for start of playback" {
+	}
+
+	if err != nil && err.Error() != "Timeout waiting for start of playback" {
 		t.Errorf("Expected timeout waiting for start of playback error, got: '%v'", err)
 	}
 
@@ -65,9 +67,11 @@ func TestQueueTimeoutSecond(t *testing.T) {
 
 	err := q.Play(ctx, player, nil)
 
-	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+	if !isTimeout(err) {
 		t.Errorf("Expected timeout error, got: '%v'", err)
-	} else if err.Error() != "Timeout waiting for stop of playback" {
+	}
+
+	if err != nil && err.Error() != "Timeout waiting for stop of playback" {
 		t.Errorf("Expected timeout waiting for stop of playback error, got: '%v'", err)
 	}
 
@@ -102,9 +106,11 @@ func TestQueueTimeoutThird(t *testing.T) {
 
 	err := q.Play(ctx, player, nil)
 
-	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+	if !isTimeout(err) {
 		t.Errorf("Expected timeout error, got: '%v'", err)
-	} else if err.Error() != "Timeout waiting for start of playback" {
+	}
+
+	if err != nil && err.Error() != "Timeout waiting for start of playback" {
 		t.Errorf("Expected timeout waiting for start of playback error, got: '%v'", err)
 	}
 
@@ -141,9 +147,11 @@ func TestQueueTimeoutFourth(t *testing.T) {
 
 	err := q.Play(ctx, player, nil)
 
-	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+	if !isTimeout(err) {
 		t.Errorf("Expected timeout error, got: '%v'", err)
-	} else if err.Error() != "Timeout waiting for stop of playback" {
+	}
+
+	if err != nil && err.Error() != "Timeout waiting for stop of playback" {
 		t.Errorf("Expected timeout waiting for stop of playback error, got: '%v'", err)
 	}
 

--- a/audio/queue_test.go
+++ b/audio/queue_test.go
@@ -1,0 +1,668 @@
+package audio
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CyCoreSystems/ari"
+	v2 "github.com/CyCoreSystems/ari/v2"
+
+	"golang.org/x/net/context"
+)
+
+type multiDummyPlayer struct {
+	players []dummyPlayer
+	C       chan struct{}
+}
+
+func (mdp *multiDummyPlayer) Play(mediaURI string) (h *ari.PlaybackHandle, err error) {
+	h = mdp.players[0].H
+	err = mdp.players[0].Err
+	mdp.players = mdp.players[1:]
+	mdp.C <- struct{}{}
+	return
+}
+
+type multiDummySubscriber struct {
+	subs map[string]*v2.Subscription
+}
+
+func (mdm *multiDummySubscriber) Subscribe(n ...string) *v2.Subscription {
+	a := v2.NewSubscription("")
+	mdm.subs[strings.Join(n, ";")] = a
+	return a
+}
+
+func TestQueueTimeout(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	err := q.Play(ctx, player, nil)
+
+	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+		t.Errorf("Expected timeout error, got: '%v'", err)
+	} else if err.Error() != "Timeout waiting for start of playback" {
+		t.Errorf("Expected timeout waiting for start of playback error, got: '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+
+}
+
+func TestQueueTimeoutSecond(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+		<-player.C // wait for play request
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+	}()
+
+	err := q.Play(ctx, player, nil)
+
+	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+		t.Errorf("Expected timeout error, got: '%v'", err)
+	} else if err.Error() != "Timeout waiting for stop of playback" {
+		t.Errorf("Expected timeout waiting for stop of playback error, got: '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+}
+
+func TestQueueTimeoutThird(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+		<-player.C // wait for play request
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		<-player.C // wait for play request
+	}()
+
+	err := q.Play(ctx, player, nil)
+
+	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+		t.Errorf("Expected timeout error, got: '%v'", err)
+	} else if err.Error() != "Timeout waiting for start of playback" {
+		t.Errorf("Expected timeout waiting for start of playback error, got: '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+
+}
+
+func TestQueueTimeoutFourth(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+
+		<-player.C // wait for first play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		<-player.C // wait for second play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb2")
+
+	}()
+
+	err := q.Play(ctx, player, nil)
+
+	if te, ok := err.(timeoutErrI); !ok || !te.IsTimeout() {
+		t.Errorf("Expected timeout error, got: '%v'", err)
+	} else if err.Error() != "Timeout waiting for stop of playback" {
+		t.Errorf("Expected timeout waiting for stop of playback error, got: '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+
+}
+
+func TestQueueSuccess(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+
+		<-player.C // wait for first play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		<-player.C // wait for second play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb2")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb2")
+
+	}()
+
+	err := q.Play(ctx, player, nil)
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+
+}
+
+func TestQueueSuccessWithEmpty(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("") // empty should just be skipped
+	q.Add("sound:2")
+
+	go func() {
+
+		<-player.C // wait for first play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		<-player.C // wait for second play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb2")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb2")
+
+	}()
+
+	err := q.Play(ctx, player, nil)
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+
+}
+
+func TestQueueExitOnDTMF(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	opts := &Options{
+		ExitOnDTMF: "3",
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+
+		<-player.C // wait for first play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		bus.subs["ChannelDtmfReceived"].C <- channelDtmf("2")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		<-player.C // wait for second play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb2")
+		bus.subs["ChannelDtmfReceived"].C <- channelDtmf("3")
+		//bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb2")
+	}()
+
+	err := q.Play(ctx, player, opts)
+
+	if err == nil || err.Error() != "context canceled" {
+		t.Errorf("Expected error 'context canceled', got '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "23" {
+		t.Errorf("Expected DTMF '23' during playback, got '%s'", dtmf)
+	}
+
+}
+
+func TestQueueExitOnDTMF100(t *testing.T) {
+	for i := 0; i != 100; i++ {
+		TestQueueExitOnDTMF(t)
+	}
+}
+
+func TestQueueDoneTrigger(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	done := make(chan struct{})
+
+	opts := &Options{
+		Done: done,
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+
+		<-player.C // wait for first play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		bus.subs["ChannelDtmfReceived"].C <- channelDtmf("2")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		<-player.C // wait for second play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb2")
+		bus.subs["ChannelDtmfReceived"].C <- channelDtmf("3")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb2")
+	}()
+
+	var err error
+	go func() {
+		err = q.Play(ctx, player, opts)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(MaxPlaybackTime * 2): // 2 because two audio clips
+		t.Errorf("options.Done never got triggered")
+	}
+
+	if err != nil {
+		t.Errorf("Unexpected error '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "23" {
+		t.Errorf("Expected DTMF '23' during playback, got '%s'", dtmf)
+	}
+}
+
+func TestQueueDTMF(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	dtmfChan := make(chan *v2.ChannelDtmfReceived, 2)
+
+	opts := &Options{
+		DTMF: dtmfChan,
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+
+		<-player.C // wait for first play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		bus.subs["ChannelDtmfReceived"].C <- channelDtmf("2")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		<-player.C // wait for second play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb2")
+		bus.subs["ChannelDtmfReceived"].C <- channelDtmf("3")
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb2")
+	}()
+
+	err := q.Play(ctx, player, opts)
+	if err != nil {
+		t.Errorf("Unexpected error '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "23" {
+		t.Errorf("Expected DTMF '23' during playback, got '%s'", dtmf)
+	}
+
+	select {
+	case e := <-dtmfChan:
+		if e.Digit != "2" {
+			t.Errorf("Expected first DTMF digit to be '2', was '%s'", e.Digit)
+		}
+	default:
+		t.Errorf("Unexpected fallthrough checking opts.DTMF output")
+	}
+
+	select {
+	case e := <-dtmfChan:
+		if e.Digit != "3" {
+			t.Errorf("Expected first DTMF digit to be '3', was '%s'", e.Digit)
+		}
+	default:
+		t.Errorf("Unexpected fallthrough checking opts.DTMF output")
+	}
+
+	select {
+	case e := <-dtmfChan:
+		t.Errorf("Unexpected third item in dtmfChan: '%v'", e)
+	default:
+	}
+
+}
+
+func TestQueueFlush(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+
+		<-player.C // wait for first play request
+
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		q.Flush()
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackFinishedGood("pb1")
+
+		select {
+		case <-player.C: // wait for second play request
+			t.Errorf("Unexpected second play after flush")
+		case <-time.After(1 * time.Second):
+		}
+
+	}()
+
+	err := q.Play(ctx, player, nil)
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+
+}
+
+func TestQueueCancel(t *testing.T) {
+	MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := &multiDummySubscriber{
+		subs: make(map[string]*v2.Subscription),
+	}
+
+	player := &multiDummyPlayer{
+		C: make(chan struct{}, 10),
+		players: []dummyPlayer{
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}),
+				Err: nil,
+			},
+			dummyPlayer{
+				H:   ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}),
+				Err: nil,
+			},
+		},
+	}
+
+	q := NewQueue(bus)
+	q.Add("sound:1")
+	q.Add("sound:2")
+
+	go func() {
+		<-player.C // wait for first play request
+		bus.subs["PlaybackStarted;PlaybackFinished"].C <- playbackStartedGood("pb1")
+		cancel()
+	}()
+
+	err := q.Play(ctx, player, nil)
+
+	if err == nil || err.Error() != "context canceled" {
+		t.Errorf("Expected error 'context canceled', got '%v'", err)
+	}
+
+	dtmf := q.ReceivedDTMF()
+	if dtmf != "" {
+		t.Errorf("Unexpected DTMF during playback: '%s'", dtmf)
+	}
+
+}

--- a/internal/testutils/bus.go
+++ b/internal/testutils/bus.go
@@ -1,38 +1,63 @@
 package testutils
 
 import (
+	"sync"
+
 	v2 "github.com/CyCoreSystems/ari/v2"
 )
 
 // Bus is a testing version of the event bus
 type Bus struct {
-	subs map[string]*v2.Subscription
+	mu   sync.RWMutex
+	subs map[string][]*v2.Subscription
 }
 
 // NewBus creates a new bus
 func NewBus() *Bus {
 	return &Bus{
-		subs: make(map[string]*v2.Subscription),
+		subs: make(map[string][]*v2.Subscription),
 	}
 }
 
 // Subscribe returns a subscription to the given list of events
-func (bus *Bus) Subscribe(nx ...string) *v2.Subscription {
-	a := v2.NewSubscription("")
+func (bus *Bus) Subscribe(nx ...string) (a *v2.Subscription) {
+
+	a = v2.NewSubscription("")
+
+	bus.mu.Lock()
 
 	for _, n := range nx {
-		bus.subs[n] = a
+		if _, ok := bus.subs[n]; !ok {
+			bus.subs[n] = make([]*v2.Subscription, 0)
+		}
+		bus.subs[n] = append(bus.subs[n], a)
 	}
+
+	bus.mu.Unlock()
 
 	return a
 }
 
 // Send sends an event to the event name
 func (bus *Bus) Send(evt v2.Eventer) {
-	bus.subs[evt.GetType()].C <- evt
+	bus.mu.RLock()
+	defer bus.mu.RUnlock()
+
+	for _, l := range bus.subs[evt.GetType()] {
+		if !l.Closed {
+			l.C <- evt
+		}
+	}
 }
 
 // SendTo sends an event to the event name
 func (bus *Bus) SendTo(n string, evt v2.Eventer) {
-	bus.subs[n].C <- evt
+	bus.mu.RLock()
+	defer bus.mu.RUnlock()
+
+	for _, l := range bus.subs[n] {
+		if !l.Closed {
+			l.C <- evt
+		}
+	}
 }

--- a/v2/bus.go
+++ b/v2/bus.go
@@ -182,6 +182,7 @@ type Subscription struct {
 	events []string     // list of events to listen for
 	C      chan Eventer // channel for sending events to the subscriber
 	mu     sync.Mutex
+	Closed bool
 }
 
 // NewSubscription creates a new, unattached subscription
@@ -222,6 +223,7 @@ func (s *Subscription) closeChan() {
 		close(s.C)
 		s.C = nil
 	}
+	s.Closed = true
 	s.mu.Unlock()
 }
 


### PR DESCRIPTION
Almost a direct port from v2. Architecture changes are noted, and are mostly about simplifying ChannelDtmfReceived.