### PR TITLE
v3 - prompt - Port of prompt package

### DIFF
--- a/prompt/doc.go
+++ b/prompt/doc.go
@@ -1,0 +1,2 @@
+// Package prompt is the utility section for working with asterisk prompts.
+package prompt

--- a/prompt/logger.go
+++ b/prompt/logger.go
@@ -1,0 +1,15 @@
+package prompt
+
+import "gopkg.in/inconshreveable/log15.v2"
+
+// Logger defaults to a discard handler (null output).
+// If you wish to enable logging, you can set your own
+// handler like so:
+// 		ari.Logger.SetHandler(log15.StderrHandler)
+//
+var Logger = log15.New()
+
+func init() {
+	// Null logger, by default
+	Logger.SetHandler(log15.DiscardHandler())
+}

--- a/prompt/matchers.go
+++ b/prompt/matchers.go
@@ -1,0 +1,60 @@
+package prompt
+
+import "strings"
+
+// MatchAny is a MatchFunc which returns Complete if the pattern
+// contains any characters.
+func MatchAny(pat string) (string, Status) {
+	if len(pat) > 0 {
+		return pat, Complete
+	}
+	return pat, Incomplete
+}
+
+// MatchHash is a MatchFunc which returns Complete if the pattern
+// contains a hash (#) character and Incomplete, otherwise.
+func MatchHash(pat string) (string, Status) {
+	if strings.Contains(pat, "#") {
+		return strings.Split(pat, "#")[0], Complete
+	}
+	return pat, Incomplete
+}
+
+// MatchTerminatorFunc is a MatchFunc which returns Complete if the pattern
+// contains the character and Incomplete, otherwise.
+func MatchTerminatorFunc(terminator string) func(string) (string, Status) {
+	return func(pat string) (string, Status) {
+		if strings.Contains(pat, terminator) {
+			return strings.Split(pat, terminator)[0], Complete
+		}
+		return pat, Incomplete
+	}
+}
+
+// MatchLenFunc returns a MatchFunc which returns
+// Complete if the given number of digits are received
+// and Incomplete otherwise.
+func MatchLenFunc(length int) func(string) (string, Status) {
+	return func(pat string) (string, Status) {
+		if len(pat) >= length {
+			return pat, Complete
+		}
+		return pat, Incomplete
+	}
+}
+
+// MatchLenOrTerminatorFunc returns a MatchFunc which returns
+// Complete if the given number of digits are received
+// or the given terminal string is received.  Otherwise,
+// it returns Incomplete.
+func MatchLenOrTerminatorFunc(length int, terminator string) func(string) (string, Status) {
+	return func(pat string) (string, Status) {
+		if len(pat) >= length {
+			return pat, Complete
+		}
+		if strings.HasSuffix(pat, terminator) {
+			return strings.TrimSuffix(pat, terminator), Complete
+		}
+		return pat, Incomplete
+	}
+}

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -1,0 +1,260 @@
+package prompt
+
+import (
+	"time"
+
+	v2 "github.com/CyCoreSystems/ari/v2"
+
+	"github.com/CyCoreSystems/ari"
+	"github.com/CyCoreSystems/ari/audio"
+	"github.com/CyCoreSystems/ari/audio/audiouri"
+
+	"golang.org/x/net/context"
+)
+
+// Options describes options for the prompt
+type Options struct {
+	// FirstDigitTimeout is the maximum length of time to wait
+	// after the prompt sequence ends for the user to enter
+	// a response.
+	// If not specified, the default is DefaultFirstDigitTimeout.
+	FirstDigitTimeout time.Duration
+
+	// InterDigitTimeout is the maximum length of time to wait
+	// for an additional digit after a digit is received.
+	// If not specified, the default is DefaultInterDigitTimeout.
+	InterDigitTimeout time.Duration
+
+	// OverallTimeout is the maximum length of time to wait
+	// for a response regardless of digits received.
+	// If not specified, the default is DefaultOverallTimeout.
+	OverallTimeout time.Duration
+
+	// EchoData is the flag for saying each digit as it is input
+	EchoData bool
+
+	// MatchFunc is an optional function which, if supplied, returns
+	// a string and an int.
+	//
+	// The string is allows the MatchFunc to return a different number
+	// to be used as `result.Data`.  This is commonly used for prompts
+	// which look for a terminator.  In such a practice, the terminator
+	// would be stripped from the match and this argument would be populated
+	// with the result.  Otherwise, the original string should be returned.
+	// NOTE: Whatever is returned here will become `result.Data`.
+	//
+	// The int parameter indicates the result of the match, and it should
+	// be one of:
+	//  Incomplete (0) : insufficient digits to determine match.
+	//  Complete (1) : A match was found.
+	//  Invalid (2) : A match could not be found, given the digits received.
+	// If this function returns a non-zero int, then the prompt will be stopped.
+	// If not specified MatchAny will be used.
+	MatchFunc func(string) (string, Status)
+
+	// Which type of word to use when playing '#'
+	SoundHash string // pound or hash
+}
+
+var (
+	// DefaultFirstDigitTimeout is the maximum time to wait for the
+	// first digit after a prompt, if not otherwise set.
+	DefaultFirstDigitTimeout = 4 * time.Second
+
+	// DefaultInterDigitTimeout is the maximum time to wait for additional
+	// digits after the first is received.
+	DefaultInterDigitTimeout = 3 * time.Second
+
+	// DefaultOverallTimeout is the maximum time to wait for a response
+	// regardless of the number of received digits or pattern matching.
+	DefaultOverallTimeout = 3 * time.Minute
+)
+
+// Prompt plays the given sound and waits for user input.
+func Prompt(ctx context.Context, bus ari.Subscriber, p audio.Player, opts *Options, sounds ...string) (ret *Result, err error) {
+	ret = &Result{}
+
+	// Handle default options
+	if opts == nil {
+		opts = &Options{}
+	}
+	if opts.FirstDigitTimeout == 0 {
+		opts.FirstDigitTimeout = DefaultFirstDigitTimeout
+	}
+	if opts.InterDigitTimeout == 0 {
+		opts.InterDigitTimeout = DefaultInterDigitTimeout
+	}
+	if opts.OverallTimeout == 0 {
+		opts.OverallTimeout = DefaultOverallTimeout
+	}
+	if opts.MatchFunc == nil {
+		opts.MatchFunc = MatchAny
+	}
+	if opts.SoundHash == "" {
+		opts.SoundHash = "hash"
+	}
+
+	// Listen for DTMF
+	dtmfSub := bus.Subscribe("ChannelDtmfReceived")
+	defer dtmfSub.Cancel()
+
+	hangupSub := bus.Subscribe("ChannelHangupRequest", "ChannelDestroyed")
+	defer hangupSub.Cancel()
+
+	// Make a play context so that the playback can
+	// be separately canceled. NOTE: if we make
+	// playCtx fork our parent context, then timeout errors
+	// can get propagated up when we don't really care about them.
+	playCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Play the prompt, if we have one
+	var promptComplete bool
+	var errChan chan error
+	if sounds != nil {
+		q := audio.NewQueue(bus)
+		q.Add(sounds...)
+		errChan = playAsync(q, playCtx, p, nil)
+	} else {
+		// If we have no prompt, it is complete
+		promptComplete = true
+	}
+
+	// Handle events while waiting for the completion of the prompt
+	// playback
+	for !promptComplete {
+		select {
+		case <-ctx.Done():
+			ret.Status = Canceled
+			err = ctx.Err()
+			return
+		case <-hangupSub.C:
+			Logger.Debug("Hangup during prompt play")
+			ret.Status = Hangup
+			return
+		case e := <-dtmfSub.C:
+			ret.Data += e.(*v2.ChannelDtmfReceived).Digit
+			Logger.Debug("DTMF received", "digits", ret.Data)
+			cancel() // cancel remaining playback
+			match, res := opts.MatchFunc(ret.Data)
+			ret.Data = match
+			if res > 0 {
+				ret.Status = res
+				return
+			}
+		case err = <-errChan:
+			if err != nil {
+				ret.Status = Failed
+				return
+			}
+			Logger.Debug("Prompt playback complete")
+			promptComplete = true
+		}
+	}
+
+	// Construct timeouts
+	timeoutChan := make(chan time.Time)
+	var interDigitTimeout = func(digits string) *time.Timer {
+		idTimer := time.AfterFunc(opts.InterDigitTimeout, func() {
+			if len(digits) == len(ret.Data) {
+				Logger.Debug("Inter-digit timeout elapsed")
+				timeoutChan <- time.Now()
+			}
+		})
+		return idTimer
+	}
+	otimer := time.AfterFunc(opts.OverallTimeout, func() {
+		// Overall timeout
+		Logger.Debug("Overall timeout elapsed")
+		timeoutChan <- time.Now()
+	})
+	defer otimer.Stop()
+
+	Logger.Debug("current data", "data", ret.Data)
+
+	var timer *time.Timer
+
+	// Apply first-digit timeout or inter-digit timeout, as appropriate
+	if len(ret.Data) == 0 {
+		timer = time.AfterFunc(opts.FirstDigitTimeout, func() {
+			// First digit timeout
+			if ret.Data == "" {
+				Logger.Debug("First-digit timeout elapsed")
+				timeoutChan <- time.Now()
+			}
+		})
+		defer timer.Stop()
+	} else {
+		// We already have digits, so the inter-digit timeout applies
+		timer = interDigitTimeout(ret.Data)
+		defer timer.Stop()
+	}
+
+	// Wait for response
+	for {
+		select {
+		case <-ctx.Done():
+			Logger.Debug("Prompt wait canceled")
+			ret.Status = Canceled
+			err = ctx.Err()
+			return
+		case <-hangupSub.C:
+			Logger.Debug("Hangup after prompt playback")
+			ret.Status = Hangup
+			return
+		case e := <-dtmfSub.C:
+			ret.Data += e.(*v2.ChannelDtmfReceived).Digit
+			Logger.Debug("DTMF received", "digits", ret.Data)
+			match, res := opts.MatchFunc(ret.Data)
+			ret.Data = match
+			if res > 0 {
+				ret.Status = res
+				return
+			}
+
+			// If we are set to echo the digits back, do so
+			if opts.EchoData {
+				go func(currentData string) {
+					Logger.Debug("Echoing digits", "data", currentData)
+
+					digitsQueue := audio.NewQueue(bus)
+					digitsQueue.Add(audiouri.DigitsURI(ret.Data, opts.SoundHash)...)
+
+					if err := digitsQueue.Play(ctx, p, nil); err != nil {
+						Logger.Error("Error saying digits", "error", err)
+					}
+
+					// Set inter-digit timeout after completion of playback
+					interDigitTimeout(currentData)
+				}(ret.Data)
+			} else {
+				// Set inter-digit timeout after completion of playback
+				interDigitTimeout(ret.Data)
+			}
+
+			// Set inter-digit timeout
+			interDigitTimeout(ret.Data)
+
+		case <-timeoutChan:
+			Logger.Debug("Timeout waiting for prompt response")
+			ret.Status = Timeout
+			return
+		}
+	}
+}
+
+// playAsync plays the queue, returing immediately with an error channel,
+// which will pass any errors and be closed on completion of the queue.
+func playAsync(pq *audio.Queue, ctx context.Context, p audio.Player, opts *audio.Options) chan error {
+	errChan := make(chan error)
+	go func() {
+		err := pq.Play(ctx, p, opts)
+		if err != nil && err.Error() != "context canceled" {
+			errChan <- err
+		}
+		close(errChan)
+		return
+	}()
+
+	return errChan
+}

--- a/prompt/prompt_test.go
+++ b/prompt/prompt_test.go
@@ -1,0 +1,945 @@
+package prompt
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"gopkg.in/inconshreveable/log15.v2"
+
+	v2 "github.com/CyCoreSystems/ari/v2"
+
+	"github.com/CyCoreSystems/ari"
+	"github.com/CyCoreSystems/ari/audio"
+	"github.com/CyCoreSystems/ari/internal/testutils"
+	"golang.org/x/net/context"
+)
+
+func TestPromptPlayError(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1", failData: true}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+	}()
+
+	res, err := Prompt(ctx, bus, player, nil, "sound:1", "sound:2")
+
+	if err == nil || err.Error() != "Dummy error getting playback data" {
+		t.Errorf("Expected dummy error getting playback error, got: '%v'", err)
+	}
+
+	if res.Status != Failed {
+		t.Errorf("Expected Failed result, got '%v'", res)
+	}
+
+	if res.Data != "" {
+		t.Errorf("Expected Data to be empty, got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptCancelBeforePromptComplete(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+	}()
+
+	cancel()
+
+	res, err := Prompt(ctx, bus, player, nil, "sound:1", "sound:2")
+
+	if err == nil || err.Error() != "context canceled" {
+		t.Errorf("Expected error 'context cancelled', got '%v'", err)
+	}
+
+	if res.Status != Canceled {
+		t.Errorf("Expected Failed result, got '%v'", res)
+	}
+
+	if res.Data != "" {
+		t.Errorf("Expected Data to be empty, got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptNoInput(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+	}()
+
+	res, err := Prompt(ctx, bus, player, nil, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Timeout {
+		t.Errorf("Expected Timeout result, got '%v'", res)
+	}
+
+	if res.Data != "" {
+		t.Errorf("Expected Data to be empty, got, got '%v'", res.Data)
+	}
+
+}
+
+func TestPromptHangup(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(&v2.ChannelHangupRequest{Event: v2.Event{Message: v2.Message{Type: "ChannelHangupRequest"}}})
+	}()
+
+	res, err := Prompt(ctx, bus, player, nil, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Hangup {
+		t.Errorf("Expected Hangup result, got '%v'", res)
+	}
+
+	if res.Data != "" {
+		t.Errorf("Expected Data to be empty, got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchHashEchoData(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	player.Append(ari.NewPlaybackHandle("d1", &testPlayback{id: "d1"}), nil)
+	player.Append(ari.NewPlaybackHandle("d2", &testPlayback{id: "d2"}), nil)
+	player.Append(ari.NewPlaybackHandle("d3", &testPlayback{id: "d3"}), nil)
+	player.Append(ari.NewPlaybackHandle("d4", &testPlayback{id: "d4"}), nil)
+	player.Append(ari.NewPlaybackHandle("d5", &testPlayback{id: "d5"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(channelDtmf("2"))
+		<-time.After(50 * time.Millisecond)
+
+		bus.Send(playbackStartedGood("d1"))
+		bus.Send(playbackFinishedGood("d1"))
+
+		bus.Send(channelDtmf("3"))
+		<-time.After(50 * time.Millisecond)
+
+		bus.Send(playbackStartedGood("d2"))
+		bus.Send(playbackFinishedGood("d2"))
+
+		bus.Send(channelDtmf("1"))
+		<-time.After(50 * time.Millisecond)
+
+		bus.Send(playbackStartedGood("d3"))
+		bus.Send(playbackFinishedGood("d3"))
+
+		bus.Send(channelDtmf("4"))
+
+		bus.Send(playbackStartedGood("d4"))
+		bus.Send(playbackFinishedGood("d4"))
+
+		<-time.After(50 * time.Millisecond)
+		bus.Send(channelDtmf("#"))
+
+		bus.Send(playbackStartedGood("d5"))
+		bus.Send(playbackFinishedGood("d5"))
+
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+	opts.EchoData = true
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "2314" {
+		t.Errorf("Expected Data to be '2314', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchHash(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("#"))
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "2314" {
+		t.Errorf("Expected Data to be '2314', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchAny(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("#"))
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchAny
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "2" {
+		t.Errorf("Expected Data to be '2', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchLenFunc(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("#"))
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchLenFunc(3)
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "231" {
+		t.Errorf("Expected Data to be '231', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchLenOrTerminatorFuncTerm(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("9"))
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchLenOrTerminatorFunc(8, "9")
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "2314" {
+		t.Errorf("Expected Data to be '2314', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchLenOrTerminatorFunc(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("9"))
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchLenOrTerminatorFunc(3, "9")
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "231" {
+		t.Errorf("Expected Data to be '231', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchTerminatorFunc(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("9"))
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchTerminatorFunc("9")
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "2314" {
+		t.Errorf("Expected Data to be '2314', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptMatchHashPrePromptComplete(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("#"))
+
+		bus.Send(playbackFinishedGood("pb1"))
+
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "2314" {
+		t.Errorf("Expected Data to be '2314', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptPostPromptHangup(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		bus.Send(&v2.ChannelHangupRequest{Event: v2.Event{Message: v2.Message{Type: "ChannelHangupRequest"}}})
+	}()
+
+	res, err := Prompt(ctx, bus, player, nil, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Hangup {
+		t.Errorf("Expected Hangup result, got '%v'", res)
+	}
+
+	if res.Data != "" {
+		t.Errorf("Expected Data to be empty, got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptNoSound100(t *testing.T) {
+	Logger.SetHandler(log15.DiscardHandler())
+	for i := 0; i != 100; i++ {
+		TestPromptNoSound(t)
+	}
+}
+
+func TestPromptNoSound(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+
+	go func() {
+		bus.Send(channelDtmf("2"))
+		bus.Send(channelDtmf("3"))
+		bus.Send(channelDtmf("1"))
+		bus.Send(channelDtmf("4"))
+		bus.Send(channelDtmf("#"))
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+
+	res, err := Prompt(ctx, bus, player, &opts)
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Complete {
+		t.Errorf("Expected Complete result, got '%v'", res)
+	}
+
+	if res.Data != "2314" {
+		t.Errorf("Expected Data to be '2314', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptInterDigitTimeout(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+	audio.Logger = log15.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+
+		// complete prompt
+
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+
+		// send initial DTMF
+		bus.Send(channelDtmf("2"))
+
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		// inter-digit timeout should trigger here
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Timeout {
+		t.Errorf("Expected Failed result, got '%v'", res.Status)
+	}
+
+	if res.Data != "2" {
+		t.Errorf("Expected Data to be '2', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptInterDigitTimeout2(t *testing.T) {
+	audio.MaxPlaybackTime = 3 * time.Second
+	audio.Logger = log15.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+
+		// send initial DTMF
+		bus.Send(channelDtmf("2"))
+
+		// complete prompt
+
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		// inter-digit timeout should trigger here
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Timeout {
+		t.Errorf("Expected Timeout result, got '%v'", res.Status)
+	}
+
+	if res.Data != "2" {
+		t.Errorf("Expected Data to be '2', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptOverrallTimeout(t *testing.T) {
+	DefaultOverallTimeout = 3 * time.Second
+	audio.MaxPlaybackTime = 3 * time.Second
+	audio.Logger = log15.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		// complete prompt
+
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		// overall timeout should trigger
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err != nil {
+		t.Errorf("Unexpected error: '%v'", err)
+	}
+
+	if res.Status != Timeout {
+		t.Errorf("Expected Timeout result, got '%v'", res.Status)
+	}
+
+	if res.Data != "" {
+		t.Errorf("Expected Data to be '', got, got '%v'", res.Data)
+	}
+}
+
+func TestPromptCancelAfterPlaybackFinished(t *testing.T) {
+	DefaultOverallTimeout = 3 * time.Second
+	audio.MaxPlaybackTime = 3 * time.Second
+	audio.Logger = log15.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := testutils.NewBus()
+
+	player := testutils.NewPlayer()
+	player.Append(ari.NewPlaybackHandle("pb1", &testPlayback{id: "pb1"}), nil)
+	player.Append(ari.NewPlaybackHandle("pb2", &testPlayback{id: "pb2"}), nil)
+
+	go func() {
+		// complete prompt
+
+		<-player.Next // play request
+		bus.Send(playbackStartedGood("pb1"))
+		bus.Send(playbackFinishedGood("pb1"))
+
+		<-player.Next
+		bus.Send(playbackStartedGood("pb2"))
+		bus.Send(playbackFinishedGood("pb2"))
+
+		<-time.After(1 * time.Second)
+
+		cancel()
+	}()
+
+	var opts Options
+	opts.MatchFunc = MatchHash
+
+	res, err := Prompt(ctx, bus, player, &opts, "sound:1", "sound:2")
+
+	if err == nil && err.Error() != "context canceled" {
+		t.Errorf("Expected error context canceled, got '%v'", err)
+	}
+
+	if res.Status != Canceled {
+		t.Errorf("Expected Canceled result, got '%v'", res.Status)
+	}
+
+	if res.Data != "" {
+		t.Errorf("Expected Data to be '', got, got '%v'", res.Data)
+	}
+}
+
+type testPlayback struct {
+	id       string
+	failData bool
+}
+
+func (p *testPlayback) Get(id string) *ari.PlaybackHandle {
+	panic("not implemented")
+}
+
+func (p *testPlayback) Data(id string) (pd ari.PlaybackData, err error) {
+	if p.failData {
+		err = errors.New("Dummy error getting playback data")
+	}
+	pd.ID = p.id
+	return
+}
+
+func (p *testPlayback) Control(id string, op string) error {
+	panic("not implemented")
+}
+
+func (p *testPlayback) Stop(id string) error {
+	panic("not implemented")
+}
+
+var channelDtmf = func(dtmf string) v2.Eventer {
+	return &v2.ChannelDtmfReceived{
+		Event: v2.Event{
+			Message: v2.Message{
+				Type: "ChannelDtmfReceived",
+			},
+		},
+		Digit: dtmf,
+	}
+}
+
+var playbackStartedGood = func(id string) v2.Eventer {
+	return &v2.PlaybackStarted{
+		Event: v2.Event{
+			Message: v2.Message{
+				Type: "PlaybackStarted",
+			},
+		},
+		Playback: v2.Playback{
+			ID: id,
+		},
+	}
+}
+
+var playbackFinishedGood = func(id string) v2.Eventer {
+	return &v2.PlaybackFinished{
+		Event: v2.Event{
+			Message: v2.Message{
+				Type: "PlaybackFinished",
+			},
+		},
+		Playback: v2.Playback{
+			ID: id,
+		},
+	}
+}
+
+var playbackStartedBadMessageType = &v2.PlaybackStarted{
+	Event: v2.Event{
+		Message: v2.Message{
+			Type: "PlaybackStarted2",
+		},
+	},
+	Playback: v2.Playback{
+		ID: "pb1",
+	},
+}
+
+var playbackFinishedBadMessageType = &v2.PlaybackFinished{
+	Event: v2.Event{
+		Message: v2.Message{
+			Type: "PlaybackFinished2",
+		},
+	},
+	Playback: v2.Playback{
+		ID: "pb1",
+	},
+}
+
+var playbackStartedDifferentPlaybackID = &v2.PlaybackStarted{
+	Event: v2.Event{
+		Message: v2.Message{
+			Type: "PlaybackStarted",
+		},
+	},
+	Playback: v2.Playback{
+		ID: "pb2",
+	},
+}
+
+var playbackFinishedDifferentPlaybackID = &v2.PlaybackFinished{
+	Event: v2.Event{
+		Message: v2.Message{
+			Type: "PlaybackFinished",
+		},
+	},
+	Playback: v2.Playback{
+		ID: "pb2",
+	},
+}

--- a/prompt/results.go
+++ b/prompt/results.go
@@ -1,0 +1,40 @@
+package prompt
+
+// Status indicates the status of the prompt
+// operation.
+type Status int
+
+const (
+	// Incomplete indicates that there are not enough digits to determine a match.
+	Incomplete Status = iota
+
+	// Complete means that a match was found from the digits received.
+	Complete
+
+	// Invalid indicates that a match cannot be found from the digits received.
+	// No more digits should be received.
+	Invalid
+
+	// Canceled indicates that matching was canceled
+	Canceled
+
+	// Timeout indicates that the matching failed due to timeout
+	Timeout
+
+	// Hangup indicates that a match could not be made due to
+	// the channel being hung up.
+	Hangup
+
+	// Failed indicates that matching could not be completed
+	// due to a failure (usually an error)
+	Failed
+)
+
+// Result describes the result of a prompt operation
+type Result struct {
+	// Data is the received data (digits) during the prompt
+	Data string
+
+	// Status is the status of the prompt play
+	Status Status
+}


### PR DESCRIPTION
Port of the prompt package to ARI v3. Requires audio, audiouri, and internal/testing packages from PR #22

Biggest changes from original code:

 * Inter-digit timer was broken.
 * Addition of SoundHash as part of Options
 * err = ctx.Err(), where appropriate
 * playCtx is unique and not part of the 'tree' anymore. Context cancellations in prompt should manually cancel playCtx so that 'context cancel' errors don't propagate up unnecessarily. (because of this I would prefer to get rid of context.Context in the audio API altogether, and use handles with Stop/Cancel... and maybe a special audio/audioctx which does nothing but audioctx.Lifecycle(ctx, playbackObject)
