### PR TITLE
v3 - nats - Proof Of Concept of nats-gw and nats client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@
 all:
 	go build ./
 	go build ./client/native
+	go build ./client/nats
 	go build ./audio
 	go build ./prompt
+
 
 build_test:
 	docker build -t test-asterisk:13.8 ./internal/dockertest

--- a/application.go
+++ b/application.go
@@ -51,6 +51,11 @@ type ApplicationHandle struct {
 	a    Application
 }
 
+// ID returns the identifier for the handle
+func (ah *ApplicationHandle) ID() string {
+	return ah.name
+}
+
 // Data retrives the data for the application
 func (ah *ApplicationHandle) Data() (ad ApplicationData, err error) {
 	ad, err = ah.a.Data(ah.name)

--- a/client/nats/application.go
+++ b/client/nats/application.go
@@ -1,0 +1,57 @@
+package nats
+
+import (
+	"errors"
+
+	"github.com/CyCoreSystems/ari"
+	"github.com/nats-io/nats"
+)
+
+type natsApplication struct {
+	conn *nats.EncodedConn
+}
+
+// Get returns a managed handle to an ARI application
+func (a *natsApplication) Get(name string) *ari.ApplicationHandle {
+	return ari.NewApplicationHandle(name, a)
+}
+
+// List returns the list of applications managed by asterisk
+func (a *natsApplication) List() (ax []*ari.ApplicationHandle, err error) {
+	var apps []string
+	err = a.conn.Request("ari.applications", "", &apps, DefaultRequestTimeout)
+	for _, app := range apps {
+		ax = append(ax, a.Get(app))
+	}
+	return
+}
+
+// Data returns the details of a given ARI application
+// Equivalent to GET /applications/{applicationName}
+func (a *natsApplication) Data(name string) (d ari.ApplicationData, err error) {
+	err = a.conn.Request("ari.applications.data."+name, "", &d, DefaultRequestTimeout)
+	return
+}
+
+// Subscribe subscribes the given application to an event source
+// Equivalent to POST /applications/{applicationName}/subscription
+func (a *natsApplication) Subscribe(name string, eventSource string) (err error) {
+	var response string
+	err = a.conn.Request("ari.applications.subscribe."+name, eventSource, &response, DefaultRequestTimeout)
+	if err == nil && response != "OK" {
+		err = errors.New(response)
+	}
+	return err
+}
+
+// Unsubscribe unsubscribes (removes a subscription to) a given
+// ARI application from the provided event source
+// Equivalent to DELETE /applications/{applicationName}/subscription
+func (a *natsApplication) Unsubscribe(name string, eventSource string) (err error) {
+	var response string
+	err = a.conn.Request("ari.applications.unsubscribe."+name, eventSource, &response, DefaultRequestTimeout)
+	if err == nil && response != "OK" {
+		err = errors.New(response)
+	}
+	return
+}

--- a/client/nats/client.go
+++ b/client/nats/client.go
@@ -1,0 +1,29 @@
+package nats
+
+import (
+	"time"
+
+	"github.com/CyCoreSystems/ari"
+	"github.com/nats-io/nats"
+)
+
+// DefaultRequestTimeout is the default timeout for a NATS request
+const DefaultRequestTimeout = 20 * time.Millisecond
+
+// New creates a new ari.Client connected to a NATS gateway ARI server
+func New(url string) (*ari.Client, error) {
+
+	nc, err := nats.Connect(url)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ari.Client{
+		Application: &natsApplication{c},
+	}, nil
+}

--- a/cmd/nats-gw/main.go
+++ b/cmd/nats-gw/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/CyCoreSystems/ari/client/native"
+	"github.com/nats-io/nats"
+	"golang.org/x/net/context"
+)
+
+func main() {
+
+	ctx := context.Background()
+
+	cl, _ := native.New(nil)
+	nc, _ := nats.Connect(nats.DefaultURL)
+	c, _ := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
+	defer c.Close()
+
+	c.Subscribe("ari.applications", func(_ string, reply string, _ string) {
+		apps, err := cl.Application.List()
+		if err != nil {
+			//TODO: what do?
+			return
+		}
+
+		var items []string
+		for _, app := range apps {
+			items = append(items, app.ID())
+		}
+
+		c.Publish(reply, items)
+	})
+
+	c.Subscribe("ari.applications.data.>", func(subj string, reply string, _ string) {
+
+		appName := strings.Join(strings.Split(subj, ".")[3:], ".")
+
+		d, err := cl.Application.Data(appName)
+		if err != nil {
+			//TODO: what do?
+			return
+		}
+
+		c.Publish(reply, d)
+	})
+
+	c.Subscribe("ari.applications.subscribe.>", func(subj string, reply string, source string) {
+
+		appName := strings.Join(strings.Split(subj, ".")[3:], ".")
+
+		err := cl.Application.Subscribe(appName, source)
+		if err != nil {
+			c.Publish(reply, err.Error())
+			return
+		}
+
+		c.Publish(reply, "OK")
+	})
+
+	c.Subscribe("ari.applications.unsubscribe.>", func(subj string, reply string, source string) {
+
+		appName := strings.Join(strings.Split(subj, ".")[3:], ".")
+
+		err := cl.Application.Unsubscribe(appName, source)
+		if err != nil {
+			c.Publish(reply, err.Error())
+			return
+		}
+
+		c.Publish(reply, "OK")
+	})
+
+	<-ctx.Done()
+
+}


### PR DESCRIPTION
Proof of concept of the nats client + ARI gateway.

A few points to be made:

 * Handles need an exposed ID (or implement JSONMarshaller/JSONUnmarshaller) to appropriately send List() responses
 * Not 100% sure how to handle error responses. Maybe have two separate Reply endpoints, one for 'errors' and one for 'responses'. That would mean we would have a custom Request type: `type Request struct { Reply string; ErrReply string; Data interface{} }`