### PR TITLE
Implement ari 3.0 - GET /recordings/stored/{recordingName}/file

### DIFF
--- a/client/mock/storedRecording.go
+++ b/client/mock/storedRecording.go
@@ -6,6 +6,7 @@ package mock
 import (
 	ari "github.com/CyCoreSystems/ari"
 	gomock "github.com/golang/mock/gomock"
+	io "io"
 )
 
 // Mock of StoredRecording interface
@@ -59,6 +60,16 @@ func (_m *MockStoredRecording) Delete(_param0 string) error {
 
 func (_mr *_MockStoredRecordingRecorder) Delete(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0)
+}
+
+func (_m *MockStoredRecording) File(_param0 string, _param1 io.Writer) error {
+	ret := _m.ctrl.Call(_m, "File", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockStoredRecordingRecorder) File(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "File", arg0, arg1)
 }
 
 func (_m *MockStoredRecording) Get(_param0 string) *ari.StoredRecordingHandle {

--- a/client/native/request.go
+++ b/client/native/request.go
@@ -91,6 +91,30 @@ func Get(conn *Conn, url string, ret interface{}) error {
 	return maybeRequestError(resp)
 }
 
+// GetCopy calls the ARI server with a GET request, and copies the response to the writer
+func getCopy(conn *Conn, url string, w io.Writer) error {
+
+	finalURL := conn.Options.URL + url
+
+	httpReq, err := buildRequest(conn, "GET", finalURL, "", nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := conn.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("Error making request: %s", err)
+	}
+
+	go func() {
+		defer resp.Body.Close()
+
+		io.Copy(w, resp.Body)
+	}()
+
+	return maybeRequestError(resp)
+}
+
 // Post calls the ARI server with a POST request.
 func Post(conn *Conn, requestURL string, ret interface{}, req interface{}) error {
 

--- a/client/native/storedRecording.go
+++ b/client/native/storedRecording.go
@@ -1,6 +1,10 @@
 package native
 
-import "github.com/CyCoreSystems/ari"
+import (
+	"io"
+
+	"github.com/CyCoreSystems/ari"
+)
 
 type nativeStoredRecording struct {
 	conn *Conn
@@ -52,5 +56,10 @@ func (sr *nativeStoredRecording) Copy(name string, dest string) (h *ari.StoredRe
 
 func (sr *nativeStoredRecording) Delete(name string) (err error) {
 	err = Delete(sr.conn, "/recordings/stored/"+name+"", nil, "")
+	return
+}
+
+func (sr *nativeStoredRecording) File(name string, w io.Writer) (err error) {
+	err = getCopy(sr.conn, "/recordings/stored/"+name+"/file", w)
 	return
 }

--- a/storedRecording.go
+++ b/storedRecording.go
@@ -1,5 +1,7 @@
 package ari
 
+import "io"
+
 // StoredRecording represents a communication path interacting with an Asterisk
 // server for stored recording resources
 type StoredRecording interface {
@@ -18,6 +20,9 @@ type StoredRecording interface {
 
 	// Delete deletes the recording
 	Delete(name string) error
+
+	// File writes the raw file contents to the given writer
+	File(name string, dest io.Writer) error
 }
 
 // StoredRecordingData is the data for a stored recording
@@ -65,5 +70,11 @@ func (s *StoredRecordingHandle) Copy(dest string) (h *StoredRecordingHandle, err
 // Delete deletes the recording
 func (s *StoredRecordingHandle) Delete() (err error) {
 	err = s.s.Delete(s.name)
+	return
+}
+
+// File writes the file to the given writer
+func (s *StoredRecordingHandle) File(w io.Writer) (err error) {
+	err = s.s.File(s.name, w)
 	return
 }


### PR DESCRIPTION
Fixes #45 

If you have a stored recording, you can call File to get its contents:

```
handle := ...

file := os.Open("/tmp/file", "w")
defer file.Close()
err := handle.File(file) // writes the file
```
- Only the native client is implemented.
#### Outstanding Issues:
- How do we implement the nats client, since we will be sending potentially large binaries over NATS? Ignore nats altogether and send a GETable HTTP url over NATS? Chunk the nats response? Call panic("Unsupported") if you try to File() over nats. @Ulexus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/59)
<!-- Reviewable:end -->
