### PR TITLE
hotfix: handles error which returns from UUID generation.

### DIFF
--- a/_examples/bridge/main.go
+++ b/_examples/bridge/main.go
@@ -89,7 +89,12 @@ func ensureBridge(ctx context.Context, cl ari.Client, src *ari.Key) (err error) 
 		return nil
 	}
 
-	key := src.New(ari.BridgeKey, uuid.NewV1().String())
+	u, err := uuid.NewV1()
+	if err != nil {
+		return err
+	}
+	key := src.New(ari.BridgeKey, u.String())
+
 	bridge, err = cl.Bridge().Create(key, "mixing", key.ID)
 	if err != nil {
 		bridge = nil

--- a/client/native/bridge.go
+++ b/client/native/bridge.go
@@ -25,7 +25,11 @@ func (b *Bridge) Create(key *ari.Key, t string, name string) (bh *ari.BridgeHand
 // StageCreate creates a new bridge handle, staged with a bridge `Create` operation.
 func (b *Bridge) StageCreate(key *ari.Key, btype, name string) (*ari.BridgeHandle, error) {
 	if key.ID == "" {
-		key.ID = uuid.NewV1().String()
+		u, err := uuid.NewV1()
+		if err != nil {
+			return nil, err
+		}
+		key.ID = u.String()
 	}
 
 	req := struct {
@@ -137,7 +141,11 @@ func (b *Bridge) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.Pl
 // StagePlay stages a `Play` operation on the bridge
 func (b *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
-		playbackID = uuid.NewV1().String()
+		u, err := uuid.NewV1()
+		if err != nil {
+			return nil, err
+		}
+		playbackID = u.String()
 	}
 
 	resp := make(map[string]interface{})

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -89,7 +89,11 @@ func (c *Channel) StageOriginate(key *ari.Key, req ari.OriginateRequest) (*ari.C
 	}
 
 	if req.ChannelID == "" {
-		req.ChannelID = uuid.NewV1().String()
+		u, err := uuid.NewV1()
+		if err != nil {
+			return nil, err
+		}
+		req.ChannelID = u.String()
 	}
 
 	return ari.NewChannelHandle(c.client.stamp(ari.NewKey(ari.ChannelKey, req.ChannelID)), c,
@@ -118,7 +122,11 @@ func (c *Channel) Create(key *ari.Key, req ari.ChannelCreateRequest) (*ari.Chann
 	}
 
 	if req.ChannelID == "" {
-		req.ChannelID = uuid.NewV1().String()
+		u, err := uuid.NewV1()
+		if err != nil {
+			return nil, err
+		}
+		req.ChannelID = u.String()
 	}
 
 	err := c.client.post("/channels/create", nil, &req)
@@ -340,7 +348,11 @@ func (c *Channel) StageSnoop(key *ari.Key, snoopID string, opts *ari.SnoopOption
 		opts = &ari.SnoopOptions{App: c.client.ApplicationName()}
 	}
 	if snoopID == "" {
-		snoopID = uuid.NewV1().String()
+		u, err := uuid.NewV1()
+		if err != nil {
+			return nil, err
+		}
+		snoopID = u.String()
 	}
 
 	// Create the snooping channel's key

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -58,9 +58,12 @@ type Options struct {
 
 // Connect creates and connects a new Client to Asterisk ARI.
 func Connect(opts *Options) (ari.Client, error) {
-	c := New(opts)
+	c, err := New(opts)
+	if err != nil {
+		return nil, err
+	}
 
-	err := c.Connect()
+	err = c.Connect()
 	if err != nil {
 		return c, err
 	}
@@ -76,7 +79,7 @@ func Connect(opts *Options) (ari.Client, error) {
 
 // New creates a new ari.Client.  This function should not be used directly unless you need finer control.
 // nolint: gocyclo
-func New(opts *Options) *Client {
+func New(opts *Options) (*Client, error) {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -86,7 +89,11 @@ func New(opts *Options) *Client {
 		if os.Getenv("ARI_APPLICATION") != "" {
 			opts.Application = os.Getenv("ARI_APPLICATION")
 		} else {
-			opts.Application = uuid.NewV1().String()
+			u, err := uuid.NewV1()
+			if err != nil {
+				return nil, err
+			}
+			opts.Application = u.String()
 		}
 	}
 
@@ -123,7 +130,7 @@ func New(opts *Options) *Client {
 	return &Client{
 		appName: opts.Application,
 		Options: opts,
-	}
+	}, nil
 }
 
 // Client describes a native ARI client, which connects directly to an Asterisk HTTP-based ARI service.

--- a/ext/play/sequence.go
+++ b/ext/play/sequence.go
@@ -41,7 +41,14 @@ func (s *sequence) Play(ctx context.Context, p ari.Player) {
 	defer close(s.done)
 
 	for u := s.s.o.uriList.First(); u != ""; u = s.s.o.uriList.Next() {
-		pb, err := p.StagePlay(uuid.NewV1().String(), u)
+		uid, err := uuid.NewV1()
+		if err != nil {
+			s.s.result.Status = Failed
+			s.s.result.Error = errors.Wrap(err, "failed to create UUID")
+			return
+		}
+
+		pb, err := p.StagePlay(uid.String(), u)
 		if err != nil {
 			s.s.result.Status = Failed
 			s.s.result.Error = errors.Wrap(err, "failed to stage playback")

--- a/ext/record/record.go
+++ b/ext/record/record.go
@@ -57,9 +57,14 @@ func defaultOptions() *Options {
 		ifExists:    "fail",
 		maxDuration: DefaultMaximumDuration,
 		maxSilence:  DefaultMaximumSilence,
-		name:        uuid.NewV1().String(),
+		name:        getUUID(),
 		terminateOn: "none",
 	}
+}
+
+func getUUID() string {
+	u, _ := uuid.NewV1()
+	return u.String()
 }
 
 func (o *Options) toRecordingOptions() *ari.RecordingOptions {


### PR DESCRIPTION
I want to resolve #81. 
This commit add support for changes in `NewV1` function which from now will return `(UUID, error)` instead of `UUID`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/82)
<!-- Reviewable:end -->
