### PR TITLE
Use rid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,6 +38,12 @@
   version = "v0.0.3"
 
 [[projects]]
+  name = "github.com/oklog/ulid"
+  packages = ["."]
+  revision = "d311cb43c92434ec4072dfbbda3400741d0a6337"
+  version = "v0.3.0"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -48,12 +54,6 @@
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
-
-[[projects]]
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/stretchr/objx"
@@ -70,7 +70,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","websocket"]
+  packages = ["websocket"]
   revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
 
 [[projects]]
@@ -82,6 +82,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b30ba972432c0ecac21d90641f373c190cd27e0dc1c827e1aa1f7c73fd5a5f17"
+  inputs-digest = "21d86ae724402357ddb4cecdc44e12d43c8c72bff8fa96eb7aabda49ac83c8bb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,13 +34,5 @@
   version = "0.8.0"
 
 [[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.2.0"
-
-[[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.1"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/net"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ protobuf: ari.proto
 api:
 	go build ./
 	go build ./stdbus
+	go build ./rid
 
 test:
 	go test `go list ./... | grep -v /vendor/`

--- a/_examples/bridge/main.go
+++ b/_examples/bridge/main.go
@@ -1,17 +1,16 @@
 package main
 
 import (
+	"context"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/inconshreveable/log15"
 
 	"github.com/CyCoreSystems/ari"
 	"github.com/CyCoreSystems/ari/client/native"
 	"github.com/CyCoreSystems/ari/ext/play"
+	"github.com/CyCoreSystems/ari/rid"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 )
 
 var ariApp = "test"
@@ -89,7 +88,7 @@ func ensureBridge(ctx context.Context, cl ari.Client, src *ari.Key) (err error) 
 		return nil
 	}
 
-	key := src.New(ari.BridgeKey, uuid.NewV1().String())
+	key := src.New(ari.BridgeKey, rid.New(rid.Bridge))
 	bridge, err = cl.Bridge().Create(key, "mixing", key.ID)
 	if err != nil {
 		bridge = nil

--- a/_examples/play/main.go
+++ b/_examples/play/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/inconshreveable/log15"
 

--- a/_examples/record/main.go
+++ b/_examples/record/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/inconshreveable/log15"
 

--- a/_examples/stasisStart/main.go
+++ b/_examples/stasisStart/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/inconshreveable/log15"
 

--- a/client/native/bridge.go
+++ b/client/native/bridge.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/CyCoreSystems/ari"
-	uuid "github.com/satori/go.uuid"
+	"github.com/CyCoreSystems/ari/rid"
 )
 
 // Bridge provides the ARI Bridge accessors for the native client
@@ -25,7 +25,7 @@ func (b *Bridge) Create(key *ari.Key, t string, name string) (bh *ari.BridgeHand
 // StageCreate creates a new bridge handle, staged with a bridge `Create` operation.
 func (b *Bridge) StageCreate(key *ari.Key, btype, name string) (*ari.BridgeHandle, error) {
 	if key.ID == "" {
-		key.ID = uuid.NewV1().String()
+		key.ID = rid.New(rid.Bridge)
 	}
 
 	req := struct {
@@ -137,7 +137,7 @@ func (b *Bridge) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.Pl
 // StagePlay stages a `Play` operation on the bridge
 func (b *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
-		playbackID = uuid.NewV1().String()
+		playbackID = rid.New(rid.Playback)
 	}
 
 	resp := make(map[string]interface{})

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -6,8 +6,7 @@ import (
 	"time"
 
 	"github.com/CyCoreSystems/ari"
-
-	"github.com/satori/go.uuid"
+	"github.com/CyCoreSystems/ari/rid"
 )
 
 // Channel provides the ARI Channel accessors for the native client
@@ -89,7 +88,7 @@ func (c *Channel) StageOriginate(key *ari.Key, req ari.OriginateRequest) (*ari.C
 	}
 
 	if req.ChannelID == "" {
-		req.ChannelID = uuid.NewV1().String()
+		req.ChannelID = rid.New(rid.Channel)
 	}
 
 	return ari.NewChannelHandle(c.client.stamp(ari.NewKey(ari.ChannelKey, req.ChannelID)), c,
@@ -118,7 +117,7 @@ func (c *Channel) Create(key *ari.Key, req ari.ChannelCreateRequest) (*ari.Chann
 	}
 
 	if req.ChannelID == "" {
-		req.ChannelID = uuid.NewV1().String()
+		req.ChannelID = rid.New(rid.Channel)
 	}
 
 	err := c.client.post("/channels/create", nil, &req)
@@ -340,7 +339,7 @@ func (c *Channel) StageSnoop(key *ari.Key, snoopID string, opts *ari.SnoopOption
 		opts = &ari.SnoopOptions{App: c.client.ApplicationName()}
 	}
 	if snoopID == "" {
-		snoopID = uuid.NewV1().String()
+		snoopID = rid.New(rid.Snoop)
 	}
 
 	// Create the snooping channel's key

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"net/url"
@@ -11,10 +12,9 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/CyCoreSystems/ari"
+	"github.com/CyCoreSystems/ari/rid"
 	"github.com/CyCoreSystems/ari/stdbus"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
-	"golang.org/x/net/context"
 	"golang.org/x/net/websocket"
 )
 
@@ -86,7 +86,7 @@ func New(opts *Options) *Client {
 		if os.Getenv("ARI_APPLICATION") != "" {
 			opts.Application = os.Getenv("ARI_APPLICATION")
 		} else {
-			opts.Application = uuid.NewV1().String()
+			opts.Application = rid.New("")
 		}
 	}
 

--- a/ext/play/play.go
+++ b/ext/play/play.go
@@ -1,8 +1,9 @@
 package play
 
 import (
+	"context"
+
 	"github.com/CyCoreSystems/ari"
-	"golang.org/x/net/context"
 )
 
 // AllDTMF is a string which contains all possible

--- a/ext/play/sequence.go
+++ b/ext/play/sequence.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/CyCoreSystems/ari"
+	"github.com/CyCoreSystems/ari/rid"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 )
 
 // sequence represents an audio sequence playback session
@@ -41,7 +41,7 @@ func (s *sequence) Play(ctx context.Context, p ari.Player) {
 	defer close(s.done)
 
 	for u := s.s.o.uriList.First(); u != ""; u = s.s.o.uriList.Next() {
-		pb, err := p.StagePlay(uuid.NewV1().String(), u)
+		pb, err := p.StagePlay(rid.New(rid.Playback), u)
 		if err != nil {
 			s.s.result.Status = Failed
 			s.s.result.Error = errors.Wrap(err, "failed to stage playback")

--- a/ext/record/record.go
+++ b/ext/record/record.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 
 	"github.com/CyCoreSystems/ari"
+	"github.com/CyCoreSystems/ari/rid"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 )
 
 var (
@@ -57,7 +57,7 @@ func defaultOptions() *Options {
 		ifExists:    "fail",
 		maxDuration: DefaultMaximumDuration,
 		maxSilence:  DefaultMaximumSilence,
-		name:        uuid.NewV1().String(),
+		name:        rid.New(rid.Recording),
 		terminateOn: "none",
 	}
 }

--- a/rid/rid.go
+++ b/rid/rid.go
@@ -1,0 +1,60 @@
+// Package rid provides unique resource IDs
+package rid
+
+import (
+	"crypto/rand"
+	"strings"
+	"time"
+
+	"github.com/oklog/ulid"
+)
+
+const (
+	// Bridge indicates the resource ID is of a bridge
+	Bridge = "br"
+
+	// Channel indicates the resource ID is of a channel
+	Channel = "ch"
+
+	// Playback indicates the resource ID is of a playback
+	Playback = "pb"
+
+	// Recording indicates the resource ID is for a recording
+	Recording = "rc"
+
+	// Snoop indicates the resource ID is for a snoop session
+	Snoop = "sn"
+)
+
+// New returns a new generic resource ID
+func New(kind string) string {
+
+	id := strings.ToLower(ulid.MustNew(ulid.Now(), rand.Reader).String())
+
+	if kind != "" {
+		if len(kind) > 2 {
+			kind = kind[:2]
+		}
+		id += "-" + kind
+	}
+
+	return id
+}
+
+// Timestamp returns the timestamp stored within the resource ID
+func Timestamp(id string) (ts time.Time, err error) {
+	idx := strings.Index(id, "-")
+	if idx > 0 {
+		id = id[:idx]
+	}
+
+	uid, err := ulid.Parse(id)
+	if err != nil {
+		return
+	}
+
+	ms := int64(uid.Time())
+	ts = time.Unix(ms/1000, (ms%1000)*1000000)
+
+	return
+}

--- a/rid/rid_test.go
+++ b/rid/rid_test.go
@@ -1,0 +1,78 @@
+package rid
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGeneric(t *testing.T) {
+
+	a := New("")
+	t.Logf("Generated ID: (%s)", a)
+
+	b := New("")
+	t.Logf("Generated ID: (%s)", b)
+
+	if a == b {
+		t.Errorf("consecutive IDs do not differ (%s) (%s)", a, b)
+		return
+	}
+
+}
+
+func TestKind(t *testing.T) {
+	a := New(Channel)
+	t.Logf("Generated channel ID: (%s)", a)
+
+	if !strings.HasSuffix(a, "-ch") {
+		t.Errorf("failed to apply proper resource suffix (%s); should have be -ch", a)
+
+	}
+}
+
+func TestKindClipping(t *testing.T) {
+	a := New("hello")
+	t.Logf("Generated hello ID: (%s)", a)
+
+	if !strings.HasSuffix(a, "-he") {
+		t.Errorf("failed to apply proper resource suffix (%s); should have been -he", a)
+
+	}
+}
+
+func TestTimestamp(t *testing.T) {
+	a := New(Channel)
+
+	ts, err := Timestamp(a)
+	if err != nil {
+		t.Error("failed to parse channel resource ID", err)
+		return
+	}
+	t.Log("parsed timestamp", ts.String())
+
+	if time.Since(ts) > time.Second {
+		t.Error("timestamp is older than a second")
+	}
+	if time.Until(ts) > time.Second {
+		t.Error("timestamp is in the future")
+	}
+}
+
+func TestTimestampGeneric(t *testing.T) {
+	a := New("")
+
+	ts, err := Timestamp(a)
+	if err != nil {
+		t.Error("failed to parse channel resource ID", err)
+		return
+	}
+	t.Log("parsed timestamp", ts.String())
+
+	if time.Since(ts) > time.Second {
+		t.Error("timestamp is older than a second")
+	}
+	if time.Until(ts) > time.Second {
+		t.Error("timestamp is in the future")
+	}
+}


### PR DESCRIPTION
This eliminates the use of the UUID library and replaces it with a custom ULID-based resource ID scheme which:
  * is chronologically-sortable
  * optionally suffixes a resource kind identifier
  * is shorter and easier to visually differentiate than UUIDs

Fixes #82 by replacement of that library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/86)
<!-- Reviewable:end -->
