### PR TITLE
Ignored error in StageOriginate?

### DIFF
--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -99,12 +99,7 @@ func (c *Channel) StageOriginate(key *ari.Key, req ari.OriginateRequest) (*ari.C
 
 			var resp response
 
-			err := c.client.post("/channels", &resp, &req)
-			if err != nil {
-				return nil
-			}
-
-			return err
+			return c.client.post("/channels", &resp, &req)
 		},
 	), nil
 }


### PR DESCRIPTION
If I read it correctly, we're currently returning nil here regardless of whether there is an error when doing originate or not. Shall we instead return the same value that we get from c.client.post(...)?

I tested by originating to unreachable destinations and the original version did not return an error, while the proposed one did. Please let me know if any more details could be helpful. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/88)
<!-- Reviewable:end -->
