### PR TITLE
bugfix: using mutex lock in the send method of the bus

### DIFF
--- a/stdbus/bus.go
+++ b/stdbus/bus.go
@@ -89,7 +89,6 @@ func (b *bus) add(s *subscription) {
 // remove deletes the given subscription from the bus
 func (b *bus) remove(s *subscription) {
 	b.rwMux.Lock()
-	defer b.rwMux.Unlock()
 	for i, si := range b.subs {
 		if s == si {
 			// Subs are pointers, so we have to explicitly remove them
@@ -97,9 +96,10 @@ func (b *bus) remove(s *subscription) {
 			b.subs[i] = b.subs[len(b.subs)-1] // replace the current with the end
 			b.subs[len(b.subs)-1] = nil       // remove the end
 			b.subs = b.subs[:len(b.subs)-1]   // lop off the end
-			return
+			break
 		}
 	}
+	b.rwMux.Unlock()
 }
 
 // A Subscription is a wrapped channel for receiving

--- a/stdbus/bus.go
+++ b/stdbus/bus.go
@@ -16,7 +16,7 @@ var subscriptionEventBufferSize = 100
 type bus struct {
 	subs []*subscription // The list of subscriptions
 
-	mu sync.Mutex
+	rwMux sync.RWMutex
 
 	closed bool
 }
@@ -45,7 +45,7 @@ func (b *bus) Close() {
 // Send sends the message to the bus
 func (b *bus) Send(e ari.Event) {
 	var matched bool
-	b.mu.Lock()
+	b.rwMux.RLock()
 
 	// Disseminate the message to the subscribers
 	for _, s := range b.subs {
@@ -68,7 +68,7 @@ func (b *bus) Send(e ari.Event) {
 		}
 	}
 
-	b.mu.Unlock()
+	b.rwMux.RUnlock()
 }
 
 // Subscribe returns a subscription to the given list
@@ -81,15 +81,15 @@ func (b *bus) Subscribe(key *ari.Key, eTypes ...string) ari.Subscription {
 
 // add appends a new subscription to the bus
 func (b *bus) add(s *subscription) {
-	b.mu.Lock()
+	b.rwMux.Lock()
 	b.subs = append(b.subs, s)
-	b.mu.Unlock()
+	b.rwMux.Unlock()
 }
 
 // remove deletes the given subscription from the bus
 func (b *bus) remove(s *subscription) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.rwMux.Lock()
+	defer b.rwMux.Unlock()
 	for i, si := range b.subs {
 		if s == si {
 			// Subs are pointers, so we have to explicitly remove them

--- a/stdbus/bus.go
+++ b/stdbus/bus.go
@@ -45,6 +45,7 @@ func (b *bus) Close() {
 // Send sends the message to the bus
 func (b *bus) Send(e ari.Event) {
 	var matched bool
+	b.mu.Lock()
 
 	// Disseminate the message to the subscribers
 	for _, s := range b.subs {
@@ -66,6 +67,8 @@ func (b *bus) Send(e ari.Event) {
 			}
 		}
 	}
+
+	b.mu.Unlock()
 }
 
 // Subscribe returns a subscription to the given list


### PR DESCRIPTION
I want to resolve #94 issue.

There is used read-write lock for increase performance.
It also trying to not use `defer`, because it adds little overhead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/95)
<!-- Reviewable:end -->
