### PR TITLE
fix: library name for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ client library.  It can be found at
 
 Install with: 
 ```sh 
-go get github.com/CycoreSystems/ari
+go get github.com/CyCoreSystems/ari
 ```
 
 # Features


### PR DESCRIPTION
The README.md states installation as `go get github.com/CycoreSystems/ari`. This causes case sensitive imports issue when used as `import "github.com/CyCoreSystems/ari"` (It raises: `cannot find package` in $GOPATH).

Also, the above camel case imports are used everywhere internally. Maybe we can keep it consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/97)
<!-- Reviewable:end -->
