### PR TITLE
Bind DeviceState data properly

### DIFF
--- a/device.go
+++ b/device.go
@@ -19,6 +19,10 @@ type DeviceStateData struct {
 	// Key is the cluster-unique identifier for this device state
 	Key *Key `json:"key"`
 
+	// Name is the name of the device
+	Name string `json:"name"`
+
+	// State is the state of the device
 	State string `json:"state"`
 }
 
@@ -62,7 +66,7 @@ func (dsh *DeviceStateHandle) Update(state string) (err error) {
 // Delete deletes the device state
 func (dsh *DeviceStateHandle) Delete() (err error) {
 	err = dsh.d.Delete(dsh.key)
-	//NOTE: if err is not nil,
+	// NOTE: if err is not nil,
 	// we could replace 'd' with a version of it
 	// that always returns ErrNotFound. Not required, as the
 	// handle could "come back" at any moment via an 'Update'

--- a/events.go
+++ b/events.go
@@ -346,7 +346,7 @@ func (evt *ContactStatusChange) Keys() (sx Keys) {
 
 // Keys returns the list of keys associated with this event
 func (evt *DeviceStateChanged) Keys() (sx Keys) {
-	sx = append(sx, evt.DeviceState.Key)
+	sx = append(sx, evt.Key(DeviceStateKey, evt.DeviceState.Name))
 	return
 }
 


### PR DESCRIPTION
DeviceStateChange should bind the device name to the key.  Also,
DeviceState is keyed by Name, which was not previously present.

Fixes #114

Signed-off-by: Seán C McCord <ulexus@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/116)
<!-- Reviewable:end -->
