### PR TITLE
Issues with Asterisk reconnect

### DIFF
--- a/client/native/client.go
+++ b/client/native/client.go
@@ -329,6 +329,18 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 			continue
 		}
 
+		info, err := c.Asterisk().Info(nil)
+		if err != nil {
+			Logger.Error("failed to get info from Asterisk", "error", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		if c.node != "" && c.node != info.SystemInfo.EntityID {
+			c.node = info.SystemInfo.EntityID
+		}
+		// We are connected again
+		c.connected = true
+
 		// Signal that we are connected (the first time only)
 		if wg != nil {
 			signalUp.Do(wg.Done)

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -306,8 +306,6 @@ func (c *Client) Connect() error {
 
 	wg.Wait()
 
-	c.connected = true
-
 	return nil
 }
 

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -336,7 +336,7 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 		if c.node != "" && c.node != info.SystemInfo.EntityID {
 			c.node = info.SystemInfo.EntityID
 		}
-		// We are connected again
+		// We are connected
 		c.connected = true
 
 		// Signal that we are connected (the first time only)


### PR DESCRIPTION
This is related to https://github.com/CyCoreSystems/ari-proxy/issues/31

The patch is not complete without a change to ari-proxy as well.
I also noticed an issue where connected bool is not set to true when a connection between ari client and Asterisk is re-established. For example after an Asterisk restart. 

This caused ari-proxy to send {"error":"ARI connection is down"} back to client, even with connection to Asterisk established.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/119)
<!-- Reviewable:end -->
