### PR TITLE
Add support for ARI redirect method

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -44,6 +44,9 @@ type Channel interface {
 	// Continue tells Asterisk to return a channel to the dialplan
 	Continue(key *Key, context, extension string, priority int) error
 
+	// Redirect tells Asterisk to redirect the channel to a different location
+	Redirect(key *Key, endpoint string) error
+
 	// Busy hangs up the channel with the "busy" cause code
 	Busy(key *Key) error
 
@@ -318,6 +321,11 @@ func (ch *ChannelHandle) Data() (*ChannelData, error) {
 // Continue tells Asterisk to return the channel to the dialplan
 func (ch *ChannelHandle) Continue(context, extension string, priority int) error {
 	return ch.c.Continue(ch.key, context, extension, priority)
+}
+
+// Redirect tells Asterisk to redirect the channel to a different location
+func (ch *ChannelHandle) Redirect(endpoint string) error {
+	return ch.c.Redirect(ch.key, endpoint)
 }
 
 //---

--- a/client/arimocks/Channel.go
+++ b/client/arimocks/Channel.go
@@ -70,6 +70,20 @@ func (_m *Channel) Continue(key *ari.Key, context string, extension string, prio
 	return r0
 }
 
+// Redirect provides a mock function with given fields: endpoint
+func (_m *Channel) Redirect(key *ari.Key, endpoint string) error {
+	ret := _m.Called(key, endpoint)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*ari.Key, string) error); ok {
+		r0 = rf(key, endpoint)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Create provides a mock function with given fields: _a0, _a1
 func (_m *Channel) Create(_a0 *ari.Key, _a1 ari.ChannelCreateRequest) (*ari.ChannelHandle, error) {
 	ret := _m.Called(_a0, _a1)

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -151,6 +151,17 @@ func (c *Channel) Continue(key *ari.Key, context, extension string, priority int
 	return c.client.post("/channels/"+key.ID+"/continue", nil, &req)
 }
 
+// Redirect tells to redirect the channel to a different location
+func (c *Channel) Redirect(key *ari.Key, endpoint string) (err error) {
+	req := struct {
+		Endpoint string `json:"endpoint"`
+	}{
+		Endpoint: endpoint,
+	}
+
+	return c.client.post("/channels/"+key.ID+"/redirect", nil, &req)
+}
+
 // Busy sends the busy status code to the channel (TODO: does this play a busy signal too)
 func (c *Channel) Busy(key *ari.Key) error {
 	return c.Hangup(key, "busy")


### PR DESCRIPTION
This PR adds support for ARI redirect method that tells Asterisk to redirect the channel to a different location.

https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+Channels+REST+API#Asterisk13ChannelsRESTAPI-redirect