### PR TITLE
Fix query parameters of externalMedia

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -120,10 +120,10 @@ type Channel interface {
 	// when `Exec`ed, by which audio may be sent or received.  The stage version
 	// of this command will not actually communicate with Asterisk until Exec is
 	// called on the returned ExternalMedia channel.
-	StageExternalMedia(key *Key, opts ExternalMediaOptions) (*ChannelHandle, error)
+	StageExternalMedia(key *Key, opts ExternalMediaOptions, variables interface{}) (*ChannelHandle, error)
 
 	// ExternalMedia creates a new non-telephony external media channel by which audio may be sent or received
-	ExternalMedia(key *Key, opts ExternalMediaOptions) (*ChannelHandle, error)
+	ExternalMedia(key *Key, opts ExternalMediaOptions, variables interface{}) (*ChannelHandle, error)
 
 	// Subscribe subscribes on the channel events
 	Subscribe(key *Key, n ...string) Subscription
@@ -264,8 +264,8 @@ type ExternalMediaOptions struct {
 	// Direction specifies the directionality of the audio stream.  Options include 'both'.  This parameter is optional and if not specified, 'both' will be used.
 	Direction string `json:"direction"`
 
-	// Variables defines the set of channel variables which should be bound to this channel upon creation.  This parameter is optional.
-	Variables map[string]string `json:"variables"`
+	// Data defines the set of channel data which should be bound to this channel upon creation.  This parameter is optional.
+	Data string `json:"data"`
 }
 
 // ChannelHandle provides a wrapper on the Channel interface for operations on a particular channel ID.
@@ -523,13 +523,13 @@ func (ch *ChannelHandle) StageSnoop(snoopID string, opts *SnoopOptions) (*Channe
 // when `Exec`ed, by which audio may be sent or received.  The stage version
 // of this command will not actually communicate with Asterisk until Exec is
 // called on the returned ExternalMedia channel.
-func (ch *ChannelHandle) StageExternalMedia(opts ExternalMediaOptions) (*ChannelHandle, error) {
-	return ch.c.StageExternalMedia(ch.key, opts)
+func (ch *ChannelHandle) StageExternalMedia(opts ExternalMediaOptions, variables interface{}) (*ChannelHandle, error) {
+	return ch.c.StageExternalMedia(ch.key, opts, variables)
 }
 
 // ExternalMedia creates a new non-telephony external media channel by which audio may be sent or received
-func (ch *ChannelHandle) ExternalMedia(opts ExternalMediaOptions) (*ChannelHandle, error) {
-	return ch.c.ExternalMedia(ch.key, opts)
+func (ch *ChannelHandle) ExternalMedia(opts ExternalMediaOptions, variables interface{}) (*ChannelHandle, error) {
+	return ch.c.ExternalMedia(ch.key, opts, variables)
 }
 
 // ----


### PR DESCRIPTION
Refer #118 

Previous `ExternalMedia` implementation uses whole `ExternalMediaOptions` as a request body.
But asterisk only uses `Variables` field as the request body. So Asterisk 18(LTS) responds as `400 Bad Request` which demand mandatory query parameters.
This patch uses `ExternalMediaOptions` as query parameters except a `Variables` which is a JSON format.

This fix is just only for the `externalMedia` API.
Go ARI uses similar approach in `channel` API(e.g. originate) like the `externalMedia` API that doesn't use query parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cycoresystems/ari/133)
<!-- Reviewable:end -->
