### PR TITLE
Allow multiple media URIs for playback

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -38,11 +38,11 @@ type Bridge interface {
 	StopMOH(key *Key) error
 
 	// Play plays the media URI to the bridge
-	Play(key *Key, playbackID string, mediaURI string) (*PlaybackHandle, error)
+	Play(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
 
 	// StagePlay stages a `Play` operation and returns the `PlaybackHandle`
 	// for invoking it.
-	StagePlay(key *Key, playbackID string, mediaURI string) (*PlaybackHandle, error)
+	StagePlay(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
 
 	// Record records the bridge
 	Record(key *Key, name string, opts *RecordingOptions) (*LiveRecordingHandle, error)

--- a/channel.go
+++ b/channel.go
@@ -93,11 +93,11 @@ type Channel interface {
 	StopSilence(key *Key) error
 
 	// Play plays the media URI to the channel
-	Play(key *Key, playbackID string, mediaURI string) (*PlaybackHandle, error)
+	Play(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
 
 	// StagePlay stages a `Play` operation and returns the `PlaybackHandle`
 	// for invoking it.
-	StagePlay(key *Key, playbackID string, mediaURI string) (*PlaybackHandle, error)
+	StagePlay(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
 
 	// Record records the channel
 	Record(key *Key, name string, opts *RecordingOptions) (*LiveRecordingHandle, error)
@@ -329,8 +329,8 @@ func (ch *ChannelHandle) Continue(context, extension string, priority int) error
 
 // Play initiates playback of the specified media uri
 // to the channel, returning the Playback handle
-func (ch *ChannelHandle) Play(id string, mediaURI string) (ph *PlaybackHandle, err error) {
-	return ch.c.Play(ch.key, id, mediaURI)
+func (ch *ChannelHandle) Play(id string, mediaURI ...string) (ph *PlaybackHandle, err error) {
+	return ch.c.Play(ch.key, id, mediaURI...)
 }
 
 // Record records the channel to the given filename
@@ -339,8 +339,8 @@ func (ch *ChannelHandle) Record(name string, opts *RecordingOptions) (*LiveRecor
 }
 
 // StagePlay stages a `Play` operation.
-func (ch *ChannelHandle) StagePlay(id string, mediaURI string) (*PlaybackHandle, error) {
-	return ch.c.StagePlay(ch.key, id, mediaURI)
+func (ch *ChannelHandle) StagePlay(id string, mediaURI ...string) (*PlaybackHandle, error) {
+	return ch.c.StagePlay(ch.key, id, mediaURI...)
 }
 
 // StageRecord stages a `Record` operation

--- a/client/arimocks/Bridge.go
+++ b/client/arimocks/Bridge.go
@@ -154,12 +154,19 @@ func (_m *Bridge) MOH(key *ari.Key, moh string) error {
 }
 
 // Play provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Bridge) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
-	ret := _m.Called(key, playbackID, mediaURI)
+func (_m *Bridge) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
+	_va := make([]interface{}, len(mediaURI))
+	for _i := range mediaURI {
+		_va[_i] = mediaURI[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, key, playbackID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, mediaURI...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -167,8 +174,8 @@ func (_m *Bridge) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.P
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, string) error); ok {
-		r1 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
+		r1 = rf(key, playbackID, mediaURI...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -237,12 +244,19 @@ func (_m *Bridge) StageCreate(key *ari.Key, btype string, name string) (*ari.Bri
 }
 
 // StagePlay provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
-	ret := _m.Called(key, playbackID, mediaURI)
+func (_m *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
+	_va := make([]interface{}, len(mediaURI))
+	for _i := range mediaURI {
+		_va[_i] = mediaURI[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, key, playbackID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, mediaURI...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -250,8 +264,8 @@ func (_m *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, string) error); ok {
-		r1 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
+		r1 = rf(key, playbackID, mediaURI...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/client/arimocks/Channel.go
+++ b/client/arimocks/Channel.go
@@ -293,12 +293,19 @@ func (_m *Channel) Originate(_a0 *ari.Key, _a1 ari.OriginateRequest) (*ari.Chann
 }
 
 // Play provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Channel) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
-	ret := _m.Called(key, playbackID, mediaURI)
+func (_m *Channel) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
+	_va := make([]interface{}, len(mediaURI))
+	for _i := range mediaURI {
+		_va[_i] = mediaURI[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, key, playbackID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, mediaURI...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -306,8 +313,8 @@ func (_m *Channel) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, string) error); ok {
-		r1 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
+		r1 = rf(key, playbackID, mediaURI...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -464,12 +471,19 @@ func (_m *Channel) StageOriginate(_a0 *ari.Key, _a1 ari.OriginateRequest) (*ari.
 }
 
 // StagePlay provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
-	ret := _m.Called(key, playbackID, mediaURI)
+func (_m *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
+	_va := make([]interface{}, len(mediaURI))
+	for _i := range mediaURI {
+		_va[_i] = mediaURI[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, key, playbackID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, mediaURI...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -477,8 +491,8 @@ func (_m *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI string) (
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, string) error); ok {
-		r1 = rf(key, playbackID, mediaURI)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
+		r1 = rf(key, playbackID, mediaURI...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/client/arimocks/Player.go
+++ b/client/arimocks/Player.go
@@ -13,12 +13,19 @@ type Player struct {
 }
 
 // Play provides a mock function with given fields: _a0, _a1
-func (_m *Player) Play(_a0 string, _a1 string) (*ari.PlaybackHandle, error) {
-	ret := _m.Called(_a0, _a1)
+func (_m *Player) Play(_a0 string, _a1 ...string) (*ari.PlaybackHandle, error) {
+	_va := make([]interface{}, len(_a1))
+	for _i := range _a1 {
+		_va[_i] = _a1[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(string, string) *ari.PlaybackHandle); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(string, ...string) *ari.PlaybackHandle); ok {
+		r0 = rf(_a0, _a1...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -26,8 +33,8 @@ func (_m *Player) Play(_a0 string, _a1 string) (*ari.PlaybackHandle, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(string, ...string) error); ok {
+		r1 = rf(_a0, _a1...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -36,12 +43,19 @@ func (_m *Player) Play(_a0 string, _a1 string) (*ari.PlaybackHandle, error) {
 }
 
 // StagePlay provides a mock function with given fields: _a0, _a1
-func (_m *Player) StagePlay(_a0 string, _a1 string) (*ari.PlaybackHandle, error) {
-	ret := _m.Called(_a0, _a1)
+func (_m *Player) StagePlay(_a0 string, _a1 ...string) (*ari.PlaybackHandle, error) {
+	_va := make([]interface{}, len(_a1))
+	for _i := range _a1 {
+		_va[_i] = _a1[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _a0)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(string, string) *ari.PlaybackHandle); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(string, ...string) *ari.PlaybackHandle); ok {
+		r0 = rf(_a0, _a1...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -49,8 +63,8 @@ func (_m *Player) StagePlay(_a0 string, _a1 string) (*ari.PlaybackHandle, error)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(string, ...string) error); ok {
+		r1 = rf(_a0, _a1...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/client/native/bridge.go
+++ b/client/native/bridge.go
@@ -155,12 +155,12 @@ func (b *Bridge) StopMOH(key *ari.Key) error {
 
 // Play attempts to play the given mediaURI on the bridge, using the playbackID
 // as the identifier to the created playback handle
-func (b *Bridge) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
+func (b *Bridge) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
 		playbackID = rid.New(rid.Playback)
 	}
 
-	h, err := b.StagePlay(key, playbackID, mediaURI)
+	h, err := b.StagePlay(key, playbackID, mediaURI...)
 	if err != nil {
 		return nil, err
 	}
@@ -169,14 +169,14 @@ func (b *Bridge) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.Pl
 }
 
 // StagePlay stages a `Play` operation on the bridge
-func (b *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
+func (b *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
 		playbackID = rid.New(rid.Playback)
 	}
 
 	resp := make(map[string]interface{})
 	req := struct {
-		Media string `json:"media"`
+		Media []string `json:"media"`
 	}{
 		Media: mediaURI,
 	}

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -271,12 +271,12 @@ func (c *Channel) StopSilence(key *ari.Key) error {
 
 // Play plays the given media URI on the channel, using the playbackID as
 // the identifier of the created ARI Playback entity
-func (c *Channel) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
+func (c *Channel) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
 		playbackID = rid.New(rid.Playback)
 	}
 
-	h, err := c.StagePlay(key, playbackID, mediaURI)
+	h, err := c.StagePlay(key, playbackID, mediaURI...)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (c *Channel) Play(key *ari.Key, playbackID string, mediaURI string) (*ari.P
 }
 
 // StagePlay stages a `Play` operation on the bridge
-func (c *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*ari.PlaybackHandle, error) {
+func (c *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
 		playbackID = rid.New(rid.Playback)
 	}
@@ -293,7 +293,7 @@ func (c *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI string) (*
 	resp := make(map[string]interface{})
 
 	req := struct {
-		Media string `json:"media"`
+		Media []string `json:"media"`
 	}{
 		Media: mediaURI,
 	}

--- a/playback.go
+++ b/playback.go
@@ -28,10 +28,10 @@ type Playback interface {
 // A Player is an entity which can play an audio URI
 type Player interface {
 	// Play plays the audio using the given playback ID and media URI
-	Play(string, string) (*PlaybackHandle, error)
+	Play(string, ...string) (*PlaybackHandle, error)
 
 	// StagePlay stages a `Play` operation
-	StagePlay(string, string) (*PlaybackHandle, error)
+	StagePlay(string, ...string) (*PlaybackHandle, error)
 
 	// Subscribe subscribes the player to events
 	Subscribe(n ...string) Subscription


### PR DESCRIPTION
This PR will allow to use https://github.com/asterisk/asterisk/commit/03d88b56565301d0552676ceb72f059b9267bca7 commit to queue multiple media URIs for playback:
```
h.StagePlay("myPlaybackID", "sound:your", "sound:extension", "sound:number", "sound:is", "digits:123")
```
Although it breaks Asterisk v13 compatibility, but its EOL is 2021-10-24.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/142)
<!-- Reviewable:end -->
