### PR TITLE
update playback api

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -38,11 +38,11 @@ type Bridge interface {
 	StopMOH(key *Key) error
 
 	// Play plays the media URI to the bridge
-	Play(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
+	Play(key *Key, playbackID string, opts interface{}) (*PlaybackHandle, error)
 
 	// StagePlay stages a `Play` operation and returns the `PlaybackHandle`
 	// for invoking it.
-	StagePlay(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
+	StagePlay(key *Key, playbackID string, opts interface{}) (*PlaybackHandle, error)
 
 	// Record records the bridge
 	Record(key *Key, name string, opts *RecordingOptions) (*LiveRecordingHandle, error)

--- a/channel.go
+++ b/channel.go
@@ -93,11 +93,11 @@ type Channel interface {
 	StopSilence(key *Key) error
 
 	// Play plays the media URI to the channel
-	Play(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
+	Play(key *Key, playbackID string, opts interface{}) (*PlaybackHandle, error)
 
 	// StagePlay stages a `Play` operation and returns the `PlaybackHandle`
 	// for invoking it.
-	StagePlay(key *Key, playbackID string, mediaURI ...string) (*PlaybackHandle, error)
+	StagePlay(key *Key, playbackID string, opts interface{}) (*PlaybackHandle, error)
 
 	// Record records the channel
 	Record(key *Key, name string, opts *RecordingOptions) (*LiveRecordingHandle, error)
@@ -329,8 +329,8 @@ func (ch *ChannelHandle) Continue(context, extension string, priority int) error
 
 // Play initiates playback of the specified media uri
 // to the channel, returning the Playback handle
-func (ch *ChannelHandle) Play(id string, mediaURI ...string) (ph *PlaybackHandle, err error) {
-	return ch.c.Play(ch.key, id, mediaURI...)
+func (ch *ChannelHandle) Play(id string, opts interface{}) (ph *PlaybackHandle, err error) {
+	return ch.c.Play(ch.key, id, opts)
 }
 
 // Record records the channel to the given filename
@@ -339,8 +339,8 @@ func (ch *ChannelHandle) Record(name string, opts *RecordingOptions) (*LiveRecor
 }
 
 // StagePlay stages a `Play` operation.
-func (ch *ChannelHandle) StagePlay(id string, mediaURI ...string) (*PlaybackHandle, error) {
-	return ch.c.StagePlay(ch.key, id, mediaURI...)
+func (ch *ChannelHandle) StagePlay(id string, opts interface{}) (*PlaybackHandle, error) {
+	return ch.c.StagePlay(ch.key, id, opts)
 }
 
 // StageRecord stages a `Record` operation

--- a/client/arimocks/Bridge.go
+++ b/client/arimocks/Bridge.go
@@ -153,20 +153,13 @@ func (_m *Bridge) MOH(key *ari.Key, moh string) error {
 	return r0
 }
 
-// Play provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Bridge) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
-	_va := make([]interface{}, len(mediaURI))
-	for _i := range mediaURI {
-		_va[_i] = mediaURI[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, key, playbackID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// Play provides a mock function with given fields: key, playbackID, opts
+func (_m *Bridge) Play(key *ari.Key, playbackID string, opts interface{}) (*ari.PlaybackHandle, error) {
+	ret := _m.Called(key, playbackID, opts)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, interface{}) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -174,8 +167,8 @@ func (_m *Bridge) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ar
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
-		r1 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, interface{}) error); ok {
+		r1 = rf(key, playbackID, opts)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -243,20 +236,13 @@ func (_m *Bridge) StageCreate(key *ari.Key, btype string, name string) (*ari.Bri
 	return r0, r1
 }
 
-// StagePlay provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
-	_va := make([]interface{}, len(mediaURI))
-	for _i := range mediaURI {
-		_va[_i] = mediaURI[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, key, playbackID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// StagePlay provides a mock function with given fields: key, playbackID, opts
+func (_m *Bridge) StagePlay(key *ari.Key, playbackID string, opts interface{}) (*ari.PlaybackHandle, error) {
+	ret := _m.Called(key, playbackID, opts)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, interface{}) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -264,8 +250,8 @@ func (_m *Bridge) StagePlay(key *ari.Key, playbackID string, mediaURI ...string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
-		r1 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, interface{}) error); ok {
+		r1 = rf(key, playbackID, opts)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/client/arimocks/Channel.go
+++ b/client/arimocks/Channel.go
@@ -292,20 +292,13 @@ func (_m *Channel) Originate(_a0 *ari.Key, _a1 ari.OriginateRequest) (*ari.Chann
 	return r0, r1
 }
 
-// Play provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Channel) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
-	_va := make([]interface{}, len(mediaURI))
-	for _i := range mediaURI {
-		_va[_i] = mediaURI[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, key, playbackID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// Play provides a mock function with given fields: key, playbackID, opts
+func (_m *Channel) Play(key *ari.Key, playbackID string, opts interface{}) (*ari.PlaybackHandle, error) {
+	ret := _m.Called(key, playbackID, opts)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, interface{}) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -313,8 +306,8 @@ func (_m *Channel) Play(key *ari.Key, playbackID string, mediaURI ...string) (*a
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
-		r1 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, interface{}) error); ok {
+		r1 = rf(key, playbackID, opts)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -470,20 +463,13 @@ func (_m *Channel) StageOriginate(_a0 *ari.Key, _a1 ari.OriginateRequest) (*ari.
 	return r0, r1
 }
 
-// StagePlay provides a mock function with given fields: key, playbackID, mediaURI
-func (_m *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
-	_va := make([]interface{}, len(mediaURI))
-	for _i := range mediaURI {
-		_va[_i] = mediaURI[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, key, playbackID)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+// StagePlay provides a mock function with given fields: key, playbackID, opts
+func (_m *Channel) StagePlay(key *ari.Key, playbackID string, opts interface{}) (*ari.PlaybackHandle, error) {
+	ret := _m.Called(key, playbackID, opts)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(*ari.Key, string, ...string) *ari.PlaybackHandle); ok {
-		r0 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(0).(func(*ari.Key, string, interface{}) *ari.PlaybackHandle); ok {
+		r0 = rf(key, playbackID, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -491,8 +477,8 @@ func (_m *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI ...string
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ari.Key, string, ...string) error); ok {
-		r1 = rf(key, playbackID, mediaURI...)
+	if rf, ok := ret.Get(1).(func(*ari.Key, string, interface{}) error); ok {
+		r1 = rf(key, playbackID, opts)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/client/arimocks/Player.go
+++ b/client/arimocks/Player.go
@@ -13,19 +13,12 @@ type Player struct {
 }
 
 // Play provides a mock function with given fields: _a0, _a1
-func (_m *Player) Play(_a0 string, _a1 ...string) (*ari.PlaybackHandle, error) {
-	_va := make([]interface{}, len(_a1))
-	for _i := range _a1 {
-		_va[_i] = _a1[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+func (_m *Player) Play(_a0 string, _a1 interface{}) (*ari.PlaybackHandle, error) {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(string, ...string) *ari.PlaybackHandle); ok {
-		r0 = rf(_a0, _a1...)
+	if rf, ok := ret.Get(0).(func(string, interface{}) *ari.PlaybackHandle); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -33,8 +26,8 @@ func (_m *Player) Play(_a0 string, _a1 ...string) (*ari.PlaybackHandle, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, ...string) error); ok {
-		r1 = rf(_a0, _a1...)
+	if rf, ok := ret.Get(1).(func(string, interface{}) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -43,19 +36,12 @@ func (_m *Player) Play(_a0 string, _a1 ...string) (*ari.PlaybackHandle, error) {
 }
 
 // StagePlay provides a mock function with given fields: _a0, _a1
-func (_m *Player) StagePlay(_a0 string, _a1 ...string) (*ari.PlaybackHandle, error) {
-	_va := make([]interface{}, len(_a1))
-	for _i := range _a1 {
-		_va[_i] = _a1[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, _a0)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+func (_m *Player) StagePlay(_a0 string, _a1 interface{}) (*ari.PlaybackHandle, error) {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 *ari.PlaybackHandle
-	if rf, ok := ret.Get(0).(func(string, ...string) *ari.PlaybackHandle); ok {
-		r0 = rf(_a0, _a1...)
+	if rf, ok := ret.Get(0).(func(string, interface{}) *ari.PlaybackHandle); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*ari.PlaybackHandle)
@@ -63,8 +49,8 @@ func (_m *Player) StagePlay(_a0 string, _a1 ...string) (*ari.PlaybackHandle, err
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, ...string) error); ok {
-		r1 = rf(_a0, _a1...)
+	if rf, ok := ret.Get(1).(func(string, interface{}) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -271,12 +271,12 @@ func (c *Channel) StopSilence(key *ari.Key) error {
 
 // Play plays the given media URI on the channel, using the playbackID as
 // the identifier of the created ARI Playback entity
-func (c *Channel) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
+func (c *Channel) Play(key *ari.Key, playbackID string, opts interface{}) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
 		playbackID = rid.New(rid.Playback)
 	}
 
-	h, err := c.StagePlay(key, playbackID, mediaURI...)
+	h, err := c.StagePlay(key, playbackID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -285,17 +285,23 @@ func (c *Channel) Play(key *ari.Key, playbackID string, mediaURI ...string) (*ar
 }
 
 // StagePlay stages a `Play` operation on the bridge
-func (c *Channel) StagePlay(key *ari.Key, playbackID string, mediaURI ...string) (*ari.PlaybackHandle, error) {
+func (c *Channel) StagePlay(key *ari.Key, playbackID string, opts interface{}) (*ari.PlaybackHandle, error) {
 	if playbackID == "" {
 		playbackID = rid.New(rid.Playback)
 	}
 
 	resp := make(map[string]interface{})
 
-	req := struct {
-		Media []string `json:"media"`
-	}{
-		Media: mediaURI,
+	var req interface{}
+	switch v := opts.(type) {
+	case string:
+		req = struct {
+			Media string `json:"media"`
+		}{
+			Media: v,
+		}
+	case ari.PlaybackOptions:
+		req = v
 	}
 
 	playbackKey := c.client.stamp(ari.NewKey(ari.PlaybackKey, playbackID))

--- a/playback.go
+++ b/playback.go
@@ -28,13 +28,28 @@ type Playback interface {
 // A Player is an entity which can play an audio URI
 type Player interface {
 	// Play plays the audio using the given playback ID and media URI
-	Play(string, ...string) (*PlaybackHandle, error)
+	Play(string, interface{}) (*PlaybackHandle, error)
 
 	// StagePlay stages a `Play` operation
-	StagePlay(string, ...string) (*PlaybackHandle, error)
+	StagePlay(string, interface{}) (*PlaybackHandle, error)
 
 	// Subscribe subscribes the player to events
 	Subscribe(n ...string) Subscription
+}
+
+// PlaybackOptions describes the parameters to the playback operation
+type PlaybackOptions struct {
+	// Media URIs to play.
+	Media []string `json:"media"`
+
+	// For sounds, selects language for sound.
+	Lang string `json:"lang,omitempty"`
+
+	// Number of milliseconds to skip before playing. Only applies to the first URI if multiple media URIs are specified.
+	OffsetMs int `json:"offsetms,omitempty"`
+
+	// Number of milliseconds to skip for forward/reverse operations.
+	SkipMs int `json:"skipms,omitempty"`
 }
 
 // PlaybackData represents the state of a playback


### PR DESCRIPTION
See #140 
This PR adds playback options and reverts the changes introduced with #142. 

```go
 // v5 api (will be still valid with v6 and asterisk v13)
h.Play("myPlaybackID", "sound:hello-world")

// v6 api
h.Play("myPlaybackID", ari.PlaybackOptions{
	Media: []string{"hello-world"}, 
	Lang: "en", 
	OffsetMs: 750,
})
h.Play("myPlaybackID", ari.PlaybackOptions{
	Media: []string{"sound:your", "sound:extension", "sound:number", "sound:is", "digits:123"}, 
})
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/143)
<!-- Reviewable:end -->
