### PR TITLE
Added Move method to channels

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -44,6 +44,9 @@ type Channel interface {
 	// Continue tells Asterisk to return a channel to the dialplan
 	Continue(key *Key, context, extension string, priority int) error
 
+	// Move moves the channel into another Stasis application
+	Move(key *Key, app string, appArgs string) error
+
 	// Busy hangs up the channel with the "busy" cause code
 	Busy(key *Key) error
 
@@ -324,6 +327,11 @@ func (ch *ChannelHandle) Data() (*ChannelData, error) {
 // Continue tells Asterisk to return the channel to the dialplan
 func (ch *ChannelHandle) Continue(context, extension string, priority int) error {
 	return ch.c.Continue(ch.key, context, extension, priority)
+}
+
+// Move moves the channel to a new Stasis app
+func (ch *ChannelHandle) Move(app string, appArgs string) error {
+	return ch.c.Move(ch.key, app, appArgs)
 }
 
 //---

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -151,6 +151,19 @@ func (c *Channel) Continue(key *ari.Key, context, extension string, priority int
 	return c.client.post("/channels/"+key.ID+"/continue", nil, &req)
 }
 
+// Move moves the channel to another stasis application
+func (c *Channel) Move(key *ari.Key, app string, appArgs string) error {
+	req := struct {
+		App     string `json:"app"`
+		AppArgs string `json:"appArgs"`
+	}{
+		App:     app,
+		AppArgs: appArgs,
+	}
+
+	return c.client.post("/channels"+key.ID+"/move", nil, &req)
+}
+
 // Busy sends the busy status code to the channel (TODO: does this play a busy signal too)
 func (c *Channel) Busy(key *ari.Key) error {
 	return c.Hangup(key, "busy")

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -161,7 +161,7 @@ func (c *Channel) Move(key *ari.Key, app string, appArgs string) error {
 		AppArgs: appArgs,
 	}
 
-	return c.client.post("/channels"+key.ID+"/move", nil, &req)
+	return c.client.post("/channels/"+key.ID+"/move", nil, &req)
 }
 
 // Busy sends the busy status code to the channel (TODO: does this play a busy signal too)


### PR DESCRIPTION
This PR attempts to implement the `/channels/{channelId}/move` endpoint described in [the documentation](https://wiki.asterisk.org/wiki/display/AST/Asterisk+20+Channels+REST+API#Asterisk20ChannelsRESTAPI-move)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/155)
<!-- Reviewable:end -->
