### PR TITLE
Connect could become stuck if the listen did not successfully connect…

### DIFF
--- a/client/native/client.go
+++ b/client/native/client.go
@@ -318,6 +318,10 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		// Exit if our context has been closed
 		if ctx.Err() != nil {
+			if wg != nil {
+				wg.Done()
+			}
+
 			return
 		}
 


### PR DESCRIPTION
… to the websocket.

listen needed to call wg.Done if the context was cancelled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/162)
<!-- Reviewable:end -->
