### PR TITLE
Resolved issue where waitgroup Done could have been called twice (resulting in an negative waitgroup count)

### DIFF
--- a/client/native/client.go
+++ b/client/native/client.go
@@ -318,6 +318,10 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		// Exit if our context has been closed
 		if ctx.Err() != nil {
+			if wg != nil {
+				wg.Done()
+			}
+
 			return
 		}
 

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -319,7 +319,7 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 		// Exit if our context has been closed
 		if ctx.Err() != nil {
 			if wg != nil {
-				wg.Done()
+				signalUp.Do(wg.Done)
 			}
 
 			return


### PR DESCRIPTION
Because a previous loop could have resulted in the sync.Once wg.Done being called, my earlier commit this morning could have resulted in the wg.Done being called twice.

This corrects the issue by correctly using the sync.Once signal for any wg.Done inside the listen goroutine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/163)
<!-- Reviewable:end -->
