### PR TITLE
Modified the native client to include a ConnectWithContext function

### DIFF
--- a/client/native/client.go
+++ b/client/native/client.go
@@ -318,6 +318,10 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		// Exit if our context has been closed
 		if ctx.Err() != nil {
+			if wg != nil {
+				wg.Done()
+			}
+
 			return
 		}
 

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -319,7 +319,7 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 		// Exit if our context has been closed
 		if ctx.Err() != nil {
 			if wg != nil {
-				wg.Done()
+				signalUp.Do(wg.Done)
 			}
 
 			return


### PR DESCRIPTION
This allows the caller to pass in their context.
ConnectWithContext then uses this Context for the cancel.
If the caller/parent cancels the Context, the child Connect routine detects the Context is closed and cleans up.
This allows for a more complex environment with multiple goroutines running under a parent/client model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/164)
<!-- Reviewable:end -->
