### PR TITLE
Added support for an optional connection up/down buffered channel to the client.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,4 +1,5 @@
 0perl <444065+0perl@users.noreply.github.com>
+Dan Cropp <dcropp@amtelco.com>
 Danil Matyukhin <postrg@gmail.com>
 JAF <baldrailers@gmail.com>
 Laurel Lawson <llawson@gmail.com>

--- a/bridge.go
+++ b/bridge.go
@@ -66,13 +66,16 @@ type BridgeData struct {
 	// Key is the cluster-unique identifier for this bridge
 	Key *Key `json:"key"`
 
-	ID         string   `json:"id"`           // Unique Id for this bridge
-	Class      string   `json:"bridge_class"` // Class of the bridge
-	Type       string   `json:"bridge_type"`  // Type of bridge (mixing, holding, dtmf_events, proxy_media)
-	ChannelIDs []string `json:"channels"`     // List of pariticipating channel ids
-	Creator    string   `json:"creator"`      // Creating entity of the bridge
-	Name       string   `json:"name"`         // The name of the bridge
-	Technology string   `json:"technology"`   // Name of the bridging technology
+	ID            string   `json:"id"`              // Unique Id for this bridge
+	Class         string   `json:"bridge_class"`    // Class of the bridge
+	Type          string   `json:"bridge_type"`     // Type of bridge (mixing, holding, dtmf_events, proxy_media)
+	ChannelIDs    []string `json:"channels"`        // List of pariticipating channel ids
+	Creator       string   `json:"creator"`         // Creating entity of the bridge
+	Name          string   `json:"name"`            // The name of the bridge
+	Technology    string   `json:"technology"`      // Name of the bridging technology
+	CreationTime  string   `json:"creationtime"`    // Creation Time
+	VideoMode     string   `json:"video_mode"`      // Video mode the bridge is using. (none, talker, sfu, single)
+	VideoSourceID string   `json:"video_source_id"` // The ID of the channel that is the source of video in this bridge, if one exists.
 }
 
 // BridgeAddChannelOptions describes additional options to be applied to a channel when it is joined to a bridge


### PR DESCRIPTION
If the caller wants to be notified every time the client detects a change in the Connected/Disconnected state for the websocket (from the last known state), it should create a buffered channel of boolean, specifying the depth for the buffered channel.
It can then pass this value in the clients Options fields.
When the Client connects for the web socket, it knows its last known connected/disconnected state.

- If it is unable to connect and the last know state was connected, it updates its last know state to disconnected. If the options Buffered channel is set, it will send a False (disconnected) message on the buffered channel.
- If it is able to connect to the Asterisk websocket and read messages, and the known state was disconnected, it changes it to connected. If the options Buffered channel is set, it will send a True (connected) message on the buffered channel.

The caller (running on a different goroutine), is responsible for retrieving any messages from the buffered channel. (Only set it if you will retrieve these messages).

When the caller Closes the client, the client will cleanup and set it's Options buffered channel reference to nil. (This lets the garbage collector know the client is no longer using it).
The caller should wait for the Close to complete. It is up to the caller to decide if it wants to read any buffered channel messages after calling Close.

The idea behind this is many telephony applications need to know when they can communicate/control calls with Asterisk. If the connection is down, an application can change it's internal state machine to know it can't communicate with Asterisk. This allows them to notify someone of a problem. Potentially switch to a different Asterisk for call control. Many more possibilities.

Additionally, added 3 more fields to the BridgeData (CreationTime, VideoMode, and VideoSourceID).