### PR TITLE
Fix sendMessage bug

### DIFF
--- a/client/native/textMessage.go
+++ b/client/native/textMessage.go
@@ -18,8 +18,11 @@ func (t *TextMessage) Send(from, tech, resource, body string, vars map[string]st
 	if vars == nil {
 		vars = map[string]string{}
 	}
+	data := map[string]interface{}{
+		"variables": vars,
+	}
 
-	return t.client.put("/endpoints/"+tech+"/"+resource+"/sendMessage?"+v.Encode(), nil, &vars)
+	return t.client.put("/endpoints/"+tech+"/"+resource+"/sendMessage?"+v.Encode(), nil, &data)
 }
 
 // SendByURI sends a text message to an endpoint by free-form URI (rather than tech/resource)
@@ -34,6 +37,9 @@ func (t *TextMessage) SendByURI(from, to, body string, vars map[string]string) e
 	if vars == nil {
 		vars = map[string]string{}
 	}
+	data := map[string]interface{}{
+		"variables": vars,
+	}
 
-	return t.client.put("/endpoints/sendMessage?"+v.Encode(), nil, &vars)
+	return t.client.put("/endpoints/sendMessage?"+v.Encode(), nil, &data)
 }

--- a/client/native/textMessage.go
+++ b/client/native/textMessage.go
@@ -18,8 +18,10 @@ func (t *TextMessage) Send(from, tech, resource, body string, vars map[string]st
 	if vars == nil {
 		vars = map[string]string{}
 	}
-	data := map[string]interface{}{
-		"variables": vars,
+	data := struct {
+		Variables map[string]string `json:"variables"`
+	}{
+		Variables: vars,
 	}
 
 	return t.client.put("/endpoints/"+tech+"/"+resource+"/sendMessage?"+v.Encode(), nil, &data)
@@ -37,8 +39,10 @@ func (t *TextMessage) SendByURI(from, to, body string, vars map[string]string) e
 	if vars == nil {
 		vars = map[string]string{}
 	}
-	data := map[string]interface{}{
-		"variables": vars,
+	data := struct {
+		Variables map[string]string `json:"variables"`
+	}{
+		Variables: vars,
 	}
 
 	return t.client.put("/endpoints/sendMessage?"+v.Encode(), nil, &data)


### PR DESCRIPTION
The sendMessage endpoints expect an object in the body like {"variables": {...}}

https://docs.asterisk.org/Asterisk_18_Documentation/API_Documentation/Asterisk_REST_Interface/Endpoints_REST_API/#sendmessage

https://docs.asterisk.org/Asterisk_18_Documentation/API_Documentation/Asterisk_REST_Interface/Endpoints_REST_API/#sendmessagetoendpoint

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/177)
<!-- Reviewable:end -->
