### PR TITLE
Crash fix - wsRead

### DIFF
--- a/client/native/client.go
+++ b/client/native/client.go
@@ -420,7 +420,9 @@ func (c *Client) wsRead(ws *websocket.Conn) chan error {
 
 			e, err := ari.DecodeEvent(data)
 			if err != nil {
-				errChan <- eris.Wrap(err, "failed to devoce websocket message to event")
+				c.Options.Logger.Error("failed to decode websocket message to event", "error", err)
+				// if decode fails, continue to next message, we can't process nil ari.Event anyway
+				continue
 			}
 
 			c.bus.Send(e)


### PR DESCRIPTION
Unmarshal errors and Unhandled events under `DecodeEvent` were always returned with an error message. 
But `c.bus.Send(e)` doesn't look for error and continues with nil Event. This creates crash down the line.

Now a fix is added to `continue` while an error message is detected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/180)
<!-- Reviewable:end -->
