### PR TITLE
Fixed TextMessage unmarshal JSON

### DIFF
--- a/textMessage.go
+++ b/textMessage.go
@@ -1,5 +1,9 @@
 package ari
 
+import (
+	"encoding/json"
+)
+
 // TextMessage needs some verbiage here
 type TextMessage interface {
 	// Send() sends a text message to an endpoint
@@ -24,4 +28,30 @@ type TextMessageData struct {
 type TextMessageVariable struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+// UnmarshalJSON parses the data into the TextMessageVariable object
+func (t *TextMessageData) UnmarshalJSON(data []byte) error {
+	// Alias to avoid recursive call
+	type Alias TextMessageData
+	aux := &struct {
+		Variables map[string]string `json:"variables"`
+		*Alias
+	}{
+		Alias: (*Alias)(t),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Convert map into slice
+	for k, v := range aux.Variables {
+		t.Variables = append(t.Variables, TextMessageVariable{
+			Key:   k,
+			Value: v,
+		})
+	}
+
+	return nil
 }


### PR DESCRIPTION
The TextMessageData.Variables field is currently defined as []TextMessageVariable, but it also needs to support JSON input where variables are provided in a map/object format, for example:

"variables": {
  "key": "value"
}
as [documented ](https://docs.asterisk.org/Asterisk_23_Documentation/API_Documentation/Asterisk_REST_Interface/Asterisk_REST_Data_Models/#textmessage)

Currently, when the TextMessageReceived event includes variables in this object format, JSON unmarshalling fails, causing the event to be dropped.

This PR adds a custom UnmarshalJSON method for the TextMessageData struct to convert JSON object-style variables into the expected slice format.
It also maintains backward compatibility with the existing JSON array structure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/188)
<!-- Reviewable:end -->
