### PR TITLE
Added Progress method to channels

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -56,6 +56,9 @@ type Channel interface {
 	// Answer answers the channel
 	Answer(key *Key) error
 
+	// Progress indicates progress on the channel
+	Progress(key *Key) error
+
 	// Hangup hangs up the given channel
 	Hangup(key *Key, reason string) error
 
@@ -395,6 +398,11 @@ func (ch *ChannelHandle) Hangup() error {
 // Answer answers the channel
 func (ch *ChannelHandle) Answer() error {
 	return ch.c.Answer(ch.key)
+}
+
+// Progress indicates progress on the channel
+func (ch *ChannelHandle) Progress() error {
+	return ch.c.Progress(ch.key)
 }
 
 // IsAnswered checks the current state of the channel to see if it is "Up"

--- a/client/native/channel.go
+++ b/client/native/channel.go
@@ -179,6 +179,11 @@ func (c *Channel) Answer(key *ari.Key) error {
 	return c.client.post("/channels/"+key.ID+"/answer", nil, nil)
 }
 
+// Progress indicates progress on the channel
+func (c *Channel) Progress(key *ari.Key) error {
+	return c.client.post("/channels/"+key.ID+"/progress", nil, nil)
+}
+
 // Ring causes a channel to start ringing (TODO: does this return an error if already ringing?)
 func (c *Channel) Ring(key *ari.Key) error {
 	return c.client.post("/channels/"+key.ID+"/ring", nil, nil)


### PR DESCRIPTION
This PR attempts to implement the /channels/{channelId}/progress endpoint described in [the documentation](https://docs.asterisk.org/Asterisk_22_Documentation/API_Documentation/Asterisk_REST_Interface/Channels_REST_API/#progress)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/189)
<!-- Reviewable:end -->
