### PR TITLE
Make bus event buffer size configurable

### DIFF
--- a/stdbus/bus.go
+++ b/stdbus/bus.go
@@ -29,9 +29,11 @@ func New() ari.Bus {
 		subs: []*subscription{},
 	}
 
-	if os.Getenv("BUS_BUFFERSIZE") != "" {
-		size := os.Getenv("BUS_BUFFERSIZE")
-		subscriptionEventBufferSize, _ = strconv.Atoi(size)
+	if size := os.Getenv("BUS_BUFFERSIZE"); size != "" {
+		sizeInt, err := strconv.Atoi(size)
+		if err == nil && sizeInt > 0 {
+			subscriptionEventBufferSize = sizeInt
+		}
 	}
 
 	return b

--- a/stdbus/bus.go
+++ b/stdbus/bus.go
@@ -2,6 +2,8 @@ package stdbus
 
 import (
 	"sync"
+	"os"
+	"strconv"
 
 	"github.com/CyCoreSystems/ari/v6"
 )
@@ -25,6 +27,11 @@ type bus struct {
 func New() ari.Bus {
 	b := &bus{
 		subs: []*subscription{},
+	}
+
+	if os.Getenv("BUS_BUFFERSIZE") != "" {
+		size := os.Getenv("BUS_BUFFERSIZE")
+		subscriptionEventBufferSize, _ = strconv.Atoi(size)
 	}
 
 	return b


### PR DESCRIPTION
Made the bus event buffer size configurable to prevent event drops under high load when subscribing to all events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/191)
<!-- Reviewable:end -->
