### PR TITLE
fix: escape recording IDs in API paths to support special characters

### DIFF
--- a/client/native/liveRecording.go
+++ b/client/native/liveRecording.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"errors"
+	"net/url"
 
 	"github.com/CyCoreSystems/ari/v6"
 )
@@ -24,7 +25,7 @@ func (lr *LiveRecording) Data(key *ari.Key) (d *ari.LiveRecordingData, err error
 	}
 
 	data := new(ari.LiveRecordingData)
-	if err := lr.client.get("/recordings/live/"+key.ID, data); err != nil {
+	if err := lr.client.get("/recordings/live/"+url.PathEscape(key.ID), data); err != nil {
 		return nil, dataGetError(err, "liveRecording", "%v", key.ID)
 	}
 
@@ -41,32 +42,32 @@ func (lr *LiveRecording) Stop(key *ari.Key) error {
 		return errors.New("liveRecording key not supplied")
 	}
 
-	return lr.client.post("/recordings/live/"+key.ID+"/stop", nil, nil)
+	return lr.client.post("/recordings/live/"+url.PathEscape(key.ID)+"/stop", nil, nil)
 }
 
 // Pause pauses the live recording (TODO: does it error if the live recording is already paused)
 func (lr *LiveRecording) Pause(key *ari.Key) error {
-	return lr.client.post("/recordings/live/"+key.ID+"/pause", nil, nil)
+	return lr.client.post("/recordings/live/"+url.PathEscape(key.ID)+"/pause", nil, nil)
 }
 
 // Resume resumes the live recording (TODO: does it error if the live recording is already resumed)
 func (lr *LiveRecording) Resume(key *ari.Key) error {
-	return lr.client.del("/recordings/live/"+key.ID+"/pause", nil, "")
+	return lr.client.del("/recordings/live/"+url.PathEscape(key.ID)+"/pause", nil, "")
 }
 
 // Mute mutes the live recording (TODO: does it error if the live recording is already muted)
 func (lr *LiveRecording) Mute(key *ari.Key) error {
-	return lr.client.post("/recordings/live/"+key.ID+"/mute", nil, nil)
+	return lr.client.post("/recordings/live/"+url.PathEscape(key.ID)+"/mute", nil, nil)
 }
 
 // Unmute unmutes the live recording (TODO: does it error if the live recording is already muted)
 func (lr *LiveRecording) Unmute(key *ari.Key) error {
-	return lr.client.del("/recordings/live/"+key.ID+"/mute", nil, "")
+	return lr.client.del("/recordings/live/"+url.PathEscape(key.ID)+"/mute", nil, "")
 }
 
 // Scrap removes a live recording (TODO: describe difference between scrap and delete)
 func (lr *LiveRecording) Scrap(key *ari.Key) error {
-	return lr.client.del("/recordings/live/"+key.ID, nil, "")
+	return lr.client.del("/recordings/live/"+url.PathEscape(key.ID), nil, "")
 }
 
 // Stored returns the StoredRecording handle for the given LiveRecording


### PR DESCRIPTION
This PR adds URL path escaping to the LiveRecording methods. Currently, the key.ID is being concatenated directly into the API endpoint strings. If a recording ID contains special characters (like slashes), the resulting URL becomes malformed, leading to 405 errors.

**Changes:**
- Imported the net/url package.
- Wrapped key.ID with url.PathEscape() in all LiveRecording methods (Data, Stop, Pause, Resume, Mute, Unmute, and Scrap).

**Why this is necessary:**
In many environments, recording names or IDs are dynamically generated and may contain characters that are not URL-safe. Using url.PathEscape ensures that the ARI (Asterisk REST Interface) receives the correct identifier regardless of its content, making the client more robust and preventing failed requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/CyCoreSystems/ari/192)
<!-- Reviewable:end -->
